### PR TITLE
feat: Implement dark mode for the application

### DIFF
--- a/euro_simulator_app copy 14/app/templates/404.html
+++ b/euro_simulator_app copy 14/app/templates/404.html
@@ -3,10 +3,67 @@
     <head>
         <title>Stránka nenalezena</title>
         <link rel="shortcut icon" href="{{ url_for('static', filename='favicon.ico') }}">
+        <style>
+            body {
+                padding: 20px;
+                font-family: sans-serif;
+                line-height: 1.6;
+                background-color: #fff; /* Default light background */
+                color: #333; /* Default dark text */
+                text-align: center;
+            }
+            .container {
+                max-width: 600px;
+                margin: 50px auto;
+                padding: 30px;
+                background-color: #f9f9f9;
+                border: 1px solid #eee;
+                border-radius: 8px;
+            }
+            h1 {
+                color: #333;
+                font-size: 2em;
+                margin-bottom: 0.5em;
+            }
+            p {
+                font-size: 1.1em;
+                margin-bottom: 1em;
+            }
+            a {
+                color: #007bff;
+                text-decoration: none;
+            }
+            a:hover {
+                color: #0056b3;
+                text-decoration: underline;
+            }
+
+            @media (prefers-color-scheme: dark) {
+                body {
+                    background-color: #121212; /* Dark background */
+                    color: #e0e0e0; /* Light text */
+                }
+                .container {
+                    background-color: #1e1e1e;
+                    border-color: #333;
+                }
+                h1 {
+                    color: #e0e0e0;
+                }
+                a {
+                    color: #90caf9; /* Lighter blue for dark background */
+                }
+                a:hover {
+                    color: #bbdefb;
+                }
+            }
+        </style>
     </head>
     <body>
-        <h1>404 - Stránka nenalezena</h1>
-        <p>Tým nebo stránka, kterou hledáte, neexistuje.</p>
-        <p><a href="{{ url_for('index') }}">Zpět na hlavní stránku</a></p>
+        <div class="container">
+            <h1>404 - Stránka nenalezena</h1>
+            <p>Tým nebo stránka, kterou hledáte, neexistuje.</p>
+            <p><a href="{{ url_for('index') }}">Zpět na hlavní stránku</a></p>
+        </div>
     </body>
 </html>

--- a/euro_simulator_app copy 14/app/templates/attribute_distributions.html
+++ b/euro_simulator_app copy 14/app/templates/attribute_distributions.html
@@ -8,35 +8,195 @@
     <script src="https://cdn.plot.ly/plotly-2.30.0.min.js"></script>
     <style>
         :root {
-            --primary-color: #007bff;
-            --primary-hover: #0056b3;
-            --secondary-color: #6c757d;
-            --secondary-hover: #5a6268;
-            --light-bg: #f8f9fa;
-            --border-color: #dee2e6;
-            --text-color: #343a40;
-            --text-muted: #6c757d;
-            --card-bg: #ffffff;
-            --header-bg: #e9ecef;
-            --success-color: #28a745;
-            --danger-color: #dc3545;
-            --stat-better: #28a745;
-            --stat-worse: #dc3545;
-            --stat-max: #17a2b8;
-            --stat-min: #ffc107;
-            --link-color: #007bff;
-            --link-hover: #0056b3;
+            /* Light Theme Variables */
+            --primary-color-light: #007bff;
+            --primary-hover-light: #0056b3;
+            --secondary-color-light: #6c757d;
+            --secondary-hover-light: #5a6268;
+            --light-bg-light: #f8f9fa; /* Used for forms, odd table rows */
+            --body-bg-light: #f4f4f4; /* Main page background */
+            --border-color-light: #dee2e6;
+            --text-color-light: #343a40;
+            --text-muted-light: #6c757d;
+            --card-bg-light: #ffffff;
+            --header-bg-light: #e9ecef;
+            --success-color-light: #28a745;
+            --danger-color-light: #dc3545;
+            --danger-hover-light: #c82333;
+            --stat-better-light: #28a745;
+            --stat-worse-light: #dc3545;
+            --stat-max-light: #17a2b8;
+            --stat-min-light: #ffc107;
+            --link-color-light: #007bff;
+            --link-hover-light: #0056b3;
+            --nav-bar-bg-light: #ffffff;
+            --select-arrow-color-light: '%236c757d'; /* #6c757d */
+            --table-hover-bg-light: #f1f1f1;
+            --details-border-light: #aaa;
+            --details-content-border-light: #eee;
+            --carousel-bg-light: #fdfdfd;
+            --carousel-header-text-light: #555;
+            --carousel-slide-text-light: #333;
+            --carousel-nav-disabled-bg-light: #ccc;
+            --group-overview-item-bg-light: #fff;
+            --group-overview-item-border-light: #e0e0e0;
+            --group-teams-table-header-text-light: #444;
+            --group-teams-table-row-border-light: #f0f0f0;
+            --th-sortable-hover-bg-light: #dde2e6;
+            --th-sortable-arrow-color-light: #333;
+            --qualifier-bg-light: #d4edda;
+            --checkbox-hover-bg-light: #e9ecef;
+            --checkbox-hover-border-light: #adb5bd;
+            --button-disabled-bg-light: #ccc;
+            --button-disabled-border-light: #bbb;
+            --button-disabled-text-light: #888;
+            --category-label-indeterminate-bg-light: #daf0FF;
+
+
+            /* Dark Theme Variables */
+            --primary-color-dark: #0d6efd;
+            --primary-hover-dark: #3385fd;
+            --secondary-color-dark: #5c636a;
+            --secondary-hover-dark: #494f54;
+            --light-bg-dark: #22272e; /* Used for forms, odd table rows */
+            --body-bg-dark: #1c2128;  /* Main page background */
+            --border-color-dark: #444c56;
+            --text-color-dark: #adbac7;
+            --text-muted-dark: #768390;
+            --card-bg-dark: #2d333b;
+            --header-bg-dark: #373e47;
+            --success-color-dark: #34c356; /* Brighter green */
+            --danger-color-dark: #f85149;  /* Brighter red */
+            --danger-hover-dark: #fa3d35;
+            --stat-better-dark: #34c356;
+            --stat-worse-dark: #f85149;
+            --stat-max-dark: #2cbce0; /* Brighter info blue */
+            --stat-min-dark: #ffca2c; /* Brighter warning yellow */
+            --link-color-dark: #2c8cff;
+            --link-hover-dark: #57a3ff;
+            --nav-bar-bg-dark: #2d333b;
+            --select-arrow-color-dark: '%23adbac7'; /* #adbac7 */
+            --table-hover-bg-dark: #373e47;
+            --details-border-dark: #555c66;
+            --details-content-border-dark: #444c56;
+            --carousel-bg-dark: #282e36;
+            --carousel-header-text-dark: #aab5c1;
+            --carousel-slide-text-dark: #adbac7;
+            --carousel-nav-disabled-bg-dark: #444c56;
+            --group-overview-item-bg-dark: #2d333b;
+            --group-overview-item-border-dark: #444c56;
+            --group-teams-table-header-text-dark: #adbac7;
+            --group-teams-table-row-border-dark: #373e47;
+            --th-sortable-hover-bg-dark: #404853;
+            --th-sortable-arrow-color-dark: #adbac7;
+            --qualifier-bg-dark: #2a5a3a !important; /* Darker green, needs !important due to specificity */
+            --checkbox-hover-bg-dark: #373e47;
+            --checkbox-hover-border-dark: #5a6268;
+            --button-disabled-bg-dark: #444c56;
+            --button-disabled-border-dark: #555c66;
+            --button-disabled-text-dark: #768390;
+            --category-label-indeterminate-bg-dark: #2a4a6e;
+
+
+            /* Default to Light Theme */
+            --primary-color: var(--primary-color-light);
+            --primary-hover: var(--primary-hover-light);
+            --secondary-color: var(--secondary-color-light);
+            --secondary-hover: var(--secondary-hover-light);
+            --light-bg: var(--light-bg-light);
+            --body-bg: var(--body-bg-light);
+            --border-color: var(--border-color-light);
+            --text-color: var(--text-color-light);
+            --text-muted: var(--text-muted-light);
+            --card-bg: var(--card-bg-light);
+            --header-bg: var(--header-bg-light);
+            --success-color: var(--success-color-light);
+            --danger-color: var(--danger-color-light);
+            --danger-hover: var(--danger-hover-light);
+            --stat-better: var(--stat-better-light);
+            --stat-worse: var(--stat-worse-light);
+            --stat-max: var(--stat-max-light);
+            --stat-min: var(--stat-min-light);
+            --link-color: var(--link-color-light);
+            --link-hover: var(--link-hover-light);
+            --nav-bar-bg: var(--nav-bar-bg-light);
+            --select-arrow-color: var(--select-arrow-color-light);
+            --table-hover-bg: var(--table-hover-bg-light);
+            --details-border: var(--details-border-light);
+            --details-content-border: var(--details-content-border-light);
+            --carousel-bg: var(--carousel-bg-light);
+            --carousel-header-text: var(--carousel-header-text-light);
+            --carousel-slide-text: var(--carousel-slide-text-light);
+            --carousel-nav-disabled-bg: var(--carousel-nav-disabled-bg-light);
+            --group-overview-item-bg: var(--group-overview-item-bg-light);
+            --group-overview-item-border: var(--group-overview-item-border-light);
+            --group-teams-table-header-text: var(--group-teams-table-header-text-light);
+            --group-teams-table-row-border: var(--group-teams-table-row-border-light);
+            --th-sortable-hover-bg: var(--th-sortable-hover-bg-light);
+            --th-sortable-arrow-color: var(--th-sortable-arrow-color-light);
+            --qualifier-bg: var(--qualifier-bg-light);
+            --checkbox-hover-bg: var(--checkbox-hover-bg-light);
+            --checkbox-hover-border: var(--checkbox-hover-border-light);
+            --button-disabled-bg: var(--button-disabled-bg-light);
+            --button-disabled-border: var(--button-disabled-border-light);
+            --button-disabled-text: var(--button-disabled-text-light);
+            --category-label-indeterminate-bg: var(--category-label-indeterminate-bg-light);
+        }
+
+        body.dark-mode {
+            --primary-color: var(--primary-color-dark);
+            --primary-hover: var(--primary-hover-dark);
+            --secondary-color: var(--secondary-color-dark);
+            --secondary-hover: var(--secondary-hover-dark);
+            --light-bg: var(--light-bg-dark);
+            --body-bg: var(--body-bg-dark);
+            --border-color: var(--border-color-dark);
+            --text-color: var(--text-color-dark);
+            --text-muted: var(--text-muted-dark);
+            --card-bg: var(--card-bg-dark);
+            --header-bg: var(--header-bg-dark);
+            --success-color: var(--success-color-dark);
+            --danger-color: var(--danger-color-dark);
+            --danger-hover: var(--danger-hover-dark);
+            --stat-better: var(--stat-better-dark);
+            --stat-worse: var(--stat-worse-dark);
+            --stat-max: var(--stat-max-dark);
+            --stat-min: var(--stat-min-dark);
+            --link-color: var(--link-color-dark);
+            --link-hover: var(--link-hover-dark);
+            --nav-bar-bg: var(--nav-bar-bg-dark);
+            --select-arrow-color: var(--select-arrow-color-dark);
+            --table-hover-bg: var(--table-hover-bg-dark);
+            --details-border: var(--details-border-dark);
+            --details-content-border: var(--details-content-border-dark);
+            --carousel-bg: var(--carousel-bg-dark);
+            --carousel-header-text: var(--carousel-header-text-dark);
+            --carousel-slide-text: var(--carousel-slide-text-dark);
+            --carousel-nav-disabled-bg: var(--carousel-nav-disabled-bg-dark);
+            --group-overview-item-bg: var(--group-overview-item-bg-dark);
+            --group-overview-item-border: var(--group-overview-item-border-dark);
+            --group-teams-table-header-text: var(--group-teams-table-header-text-dark);
+            --group-teams-table-row-border: var(--group-teams-table-row-border-dark);
+            --th-sortable-hover-bg: var(--th-sortable-hover-bg-dark);
+            --th-sortable-arrow-color: var(--th-sortable-arrow-color-dark);
+            --qualifier-bg: var(--qualifier-bg-dark);
+            --checkbox-hover-bg: var(--checkbox-hover-bg-dark);
+            --checkbox-hover-border: var(--checkbox-hover-border-dark);
+            --button-disabled-bg: var(--button-disabled-bg-dark);
+            --button-disabled-border: var(--button-disabled-border-dark);
+            --button-disabled-text: var(--button-disabled-text-dark);
+            --category-label-indeterminate-bg: var(--category-label-indeterminate-bg-dark);
         }
 
         body {
             font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
             margin: 0;
-            padding: 20px;
+            padding: 20px; /* Initial padding, might be overridden by body padding-top for fixed nav */
             line-height: 1.6;
-            background-color: #f4f4f4;
+            background-color: var(--body-bg); /* Updated */
             color: var(--text-color);
             position: relative;
-            padding-top: 80px;
+            padding-top: 80px; /* Adjust if nav height changes */
         }
 
         .container {
@@ -100,7 +260,7 @@
             top: 0;
             left: 0;
             right: 0;
-            background-color: white;
+            background-color: var(--nav-bar-bg); /* Updated */
             box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
             z-index: 1000;
             padding: 10px 25px;
@@ -108,18 +268,34 @@
             justify-content: space-between;
             align-items: center;
             transition: transform 0.3s ease-in-out;
-            flex-wrap: wrap;
+            flex-wrap: wrap; /* Allow wrapping for toggle button */
         }
 
         .nav-title {
             font-weight: 600;
             font-size: 1.2em;
             color: var(--text-color);
-            flex-grow: 1;
+            flex-grow: 1; /* Allow title to take space */
+        }
+        
+        #darkModeToggle { /* Style for the new button */
+            background-color: var(--secondary-color);
+            color: white;
+            border: none;
+            padding: 8px 12px;
+            border-radius: 6px;
+            cursor: pointer;
+            font-size: 0.9em;
+            margin-left: 15px; /* Space from nav links or toggle */
+            order: 3; /* Ensure it comes after nav-links if they wrap */
+        }
+        body.dark-mode #darkModeToggle {
+            background-color: var(--primary-color);
         }
 
+
         .nav-toggle {
-            display: none;
+            display: none; /* Hidden by default, shown in media query */
             background: none;
             border: none;
             font-size: 1.8em;
@@ -127,12 +303,14 @@
             color: var(--primary-color);
             padding: 0 5px;
             line-height: 1;
-            margin-left: 15px;
+            margin-left: 10px; /* Space from title or links */
         }
 
         .nav-links {
             display: flex;
             align-items: center;
+            /* flex-grow: 1; /* Allow links to take up space and push toggle to end */
+            /* justify-content: flex-end; */
         }
 
         .nav-links a {
@@ -178,9 +356,9 @@
 
         button:disabled,
         a.button-link:disabled {
-            background-color: #ccc !important;
-            border-color: #bbb !important;
-            color: #888 !important;
+            background-color: var(--button-disabled-bg) !important; /* Updated */
+            border-color: var(--button-disabled-border) !important; /* Updated */
+            color: var(--button-disabled-text) !important; /* Updated */
             cursor: not-allowed !important;
             opacity: 0.65 !important;
         }
@@ -191,6 +369,10 @@
             border-color: var(--primary-color);
             color: white;
         }
+        body.dark-mode .btn-primary, body.dark-mode button.main-submit { /* Ensure contrast for dark mode */
+            color: #fff;
+        }
+
 
         .btn-primary:hover,
         button.main-submit:hover {
@@ -206,6 +388,9 @@
             background-color: var(--secondary-color);
             border-color: var(--secondary-color);
             color: white;
+        }
+        body.dark-mode .btn-secondary, body.dark-mode a.reset-button, body.dark-mode a.back-button { /* Ensure contrast for dark mode */
+            color: #fff;
         }
 
         .btn-secondary:hover,
@@ -291,15 +476,23 @@
 
         select {
             appearance: none;
-            background-image: url('data:image/svg+xml;charset=US-ASCII,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22292.4%22%20height%3D%22292.4%22%3E%3Cpath%20fill%3D%22%236c757d%22%20d%3D%22M287%2069.4a17.6%2017.6%200%200%200-13-5.4H18.4c-5%200-9.3%201.8-12.9%205.4A17.6%2017.6%200%200%200%200%2082.2c0%205%201.8%209.3%205.4%2012.9l128%20127.9c3.6%203.6%207.8%205.4%2012.8%205.4s9.2-1.8%2012.8-5.4L287%2095c3.6-3.6%205.4-7.8%205.4-12.8%200-5-1.8-9.2-5.4-12.8z%22%2F%3E%3C%2Fsvg%3E');
+            /* The fill color in the SVG URL needs to be dynamic. We use a CSS variable. */
+            background-image: url('data:image/svg+xml;charset=US-ASCII,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22292.4%22%20height%3D%22292.4%22%3E%3Cpath%20fill%3D%22' + var(--select-arrow-color) + '%22%20d%3D%22M287%2069.4a17.6%2017.6%200%200%200-13-5.4H18.4c-5%200-9.3%201.8-12.9%205.4A17.6%2017.6%200%200%200%200%2082.2c0%205%201.8%209.3%205.4%2012.9l128%20127.9c3.6%203.6%207.8%205.4%2012.8%205.4s9.2-1.8%2012.8-5.4L287%2095c3.6-3.6%205.4-7.8%205.4-12.8%200-5-1.8-9.2-5.4-12.8z%22%2F%3E%3C%2Fsvg%3E');
             background-repeat: no-repeat;
             background-position: right 12px center;
             background-size: 10px 10px;
             padding-right: 35px;
         }
+        body:not(.dark-mode) select {
+             background-image: url('data:image/svg+xml;charset=US-ASCII,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22292.4%22%20height%3D%22292.4%22%3E%3Cpath%20fill%3D%22%236c757d%22%20d%3D%22M287%2069.4a17.6%2017.6%200%200%200-13-5.4H18.4c-5%200-9.3%201.8-12.9%205.4A17.6%2017.6%200%200%200%200%2082.2c0%205%201.8%209.3%205.4%2012.9l128%20127.9c3.6%203.6%207.8%205.4%2012.8%205.4s9.2-1.8%2012.8-5.4L287%2095c3.6-3.6%205.4-7.8%205.4-12.8%200-5-1.8-9.2-5.4-12.8z%22%2F%3E%3C%2Fsvg%3E');
+        }
+        body.dark-mode select {
+            background-image: url('data:image/svg+xml;charset=US-ASCII,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22292.4%22%20height%3D%22292.4%22%3E%3Cpath%20fill%3D%22%23adbac7%22%20d%3D%22M287%2069.4a17.6%2017.6%200%200%200-13-5.4H18.4c-5%200-9.3%201.8-12.9%205.4A17.6%2017.6%200%200%200%200%2082.2c0%205%201.8%209.3%205.4%2012.9l128%20127.9c3.6%203.6%207.8%205.4%2012.8%205.4s9.2-1.8%2012.8-5.4L287%2095c3.6-3.6%205.4-7.8%205.4-12.8%200-5-1.8-9.2-5.4-12.8z%22%2F%3E%3C%2Fsvg%3E');
+        }
+
 
         select:disabled {
-            background-color: #e9ecef;
+            background-color: var(--header-bg); /* Use variable */
             cursor: not-allowed;
             opacity: 0.7;
         }
@@ -316,7 +509,7 @@
             margin-bottom: 10px;
         }
 
-        .checkbox-group {
+        .checkbox-group { /* This is for attribute specifics */
             display: flex;
             flex-wrap: wrap;
             gap: 8px 12px;
@@ -327,7 +520,7 @@
             display: none;
         }
 
-        .checkbox-group label,
+        .checkbox-group label, /* This is for attribute specifics */
         .radio-group label.radio-label {
             display: inline-block;
             padding: 8px 12px;
@@ -343,13 +536,13 @@
             white-space: nowrap;
             font-size: 0.9em;
             text-align: center;
-            flex-grow: 1;
+            flex-grow: 1; /* For radio labels */
         }
 
-        .checkbox-group label {
+        .checkbox-group label { /* This is for attribute specifics, making them pills */
             border-radius: 18px;
             padding: 6px 14px;
-            flex-grow: 0;
+            flex-grow: 0; /* Don't grow for pills */
         }
 
 
@@ -359,11 +552,16 @@
             color: white;
             border-color: var(--primary-hover);
         }
+        body.dark-mode .checkbox-group input[type="checkbox"]:checked+label,
+        body.dark-mode .radio-group input[type="radio"]:checked+label.radio-label {
+            color: #fff; /* Ensure text is white */
+        }
+
 
         .checkbox-group input[type="checkbox"]:not(:checked)+label:hover,
         .radio-group input[type="radio"]:not(:checked)+label.radio-label:hover {
-            background-color: #e9ecef;
-            border-color: #adb5bd;
+            background-color: var(--checkbox-hover-bg); /* Use variable */
+            border-color: var(--checkbox-hover-border); /* Use variable */
             color: var(--text-color);
         }
 
@@ -412,8 +610,8 @@
         }
 
         .attribute-category-checkbox:not(:checked)+label.category-label:hover {
-            background-color: #dde2e6;
-            border-color: #adb5bd;
+            background-color: var(--checkbox-hover-bg); /* Updated */
+            border-color: var(--checkbox-hover-border); /* Updated */
         }
 
         .attribute-category-checkbox:checked+label.category-label {
@@ -421,19 +619,28 @@
             color: white;
             border-color: var(--primary-hover);
         }
+        body.dark-mode .attribute-category-checkbox:checked+label.category-label {
+            color: #fff;
+        }
 
         .attribute-category-checkbox:indeterminate+label.category-label {
-            background-color: var(--secondary-color);
+            background-color: var(--secondary-color); /* Fallback, should be themed */
             color: white;
             border-color: var(--secondary-hover);
         }
+        body.dark-mode .attribute-category-checkbox:indeterminate+label.category-label {
+            background-color: var(--secondary-color-dark);
+            color: #fff;
+            border-color: var(--secondary-hover-dark);
+        }
+
 
         .attribute-specifics-container {
             padding-left: 10px;
             margin-top: 8px;
         }
 
-        .attribute-specifics-container .checkbox-group {
+        .attribute-specifics-container .checkbox-group { /* This is for attribute specifics */
             padding-top: 5px;
         }
 
@@ -457,64 +664,41 @@
             display: none;
         }
 
-        label.category-label.category-label-checked {
+        label.category-label.category-label-checked { /* This is for position categories, JS controlled */
             background-color: var(--primary-color) !important;
             color: white !important;
             border-color: var(--primary-hover) !important;
         }
+        body.dark-mode label.category-label.category-label-checked {
+            color: #fff !important;
+        }
 
-        label.category-label.category-label-indeterminate {
-            background-color: #daf0FF !important;
-            color: var(--primary-hover) !important;
+
+        label.category-label.category-label-indeterminate { /* This is for position categories, JS controlled */
+            background-color: var(--category-label-indeterminate-bg) !important; /* Updated */
+            color: var(--primary-hover) !important; /* This might need review for dark mode */
             border-color: var(--primary-color) !important;
         }
+        body.dark-mode label.category-label.category-label-indeterminate {
+             color: var(--primary-hover-dark) !important; /* Check if this is desired */
+        }
+
 
         .position-specifics-container {
             padding-left: 10px;
             margin-top: 8px;
         }
 
-        .position-specifics-container .checkbox-group {
+        .position-specifics-container .checkbox-group { /*This is for position specifics */
             padding-top: 5px;
         }
 
-        .position-category-checkbox:not(:checked)+label.category-label:hover {
-            background-color: #dde2e6 !important;
-            border-color: #adb5bd !important;
-        }
 
-        label.category-label {
-            display: inline-block;
-            padding: 8px 16px;
-            border: 1px solid var(--border-color);
-            border-radius: 18px;
-            background-color: var(--light-bg);
-            color: var(--text-color);
-            cursor: pointer;
-            transition: all 0.2s ease;
-            font-weight: 600;
-            margin: 0;
-            line-height: 1.4;
-            white-space: nowrap;
-            font-size: 0.95em;
-        }
-
+        /* General hover for non-checked category labels (both attribute and position) */
         .attribute-category-checkbox:not(:checked)+label.category-label:hover,
         .position-category-checkbox:not(:checked)+label.category-label:hover {
-            background-color: #dde2e6 !important;
-            border-color: #adb5bd !important;
-        }
-
-        .attribute-category-checkbox:checked+label.category-label {
-            background-color: var(--primary-color);
-            color: white;
-            border-color: var(--primary-hover);
-        }
-
-        .attribute-category-checkbox:indeterminate+label.category-label {
-            background-color: #daf0FF !important;
-            color: var(--primary-hover) !important;
-            border-color: var(--primary-color) !important;
+            background-color: var(--checkbox-hover-bg) !important; /* Updated, ensure specificity */
+            border-color: var(--checkbox-hover-border) !important; /* Updated */
         }
 
         table {
@@ -555,7 +739,7 @@
         }
 
         tbody tr:hover {
-            background-color: #f1f1f1;
+            background-color: var(--table-hover-bg); /* Updated */
         }
 
         td.number,
@@ -574,7 +758,7 @@
         }
 
         th.sortable:hover {
-            background-color: #dde2e6;
+            background-color: var(--th-sortable-hover-bg); /* Updated */
         }
 
         th.sortable::after {
@@ -588,12 +772,12 @@
         }
 
         th.sortable.sort-asc::after {
-            border-bottom-color: #333;
+            border-bottom-color: var(--th-sortable-arrow-color); /* Updated */
             opacity: 1;
         }
 
         th.sortable.sort-desc::after {
-            border-top-color: #333;
+            border-top-color: var(--th-sortable-arrow-color); /* Updated */
             opacity: 1;
         }
 
@@ -645,8 +829,12 @@
         }
 
         tr.qualifier {
-            background-color: #d4edda !important;
+            background-color: var(--qualifier-bg) !important; /* Updated */
         }
+        body.dark-mode tr.qualifier td { /* Ensure text is readable on dark qualifier bg */
+            color: #e1e8ef; /* A light text color */
+        }
+
 
         .player-card {
             background-color: var(--card-bg);
@@ -675,7 +863,7 @@
         .player-card h2 {
             margin-top: 0;
             margin-bottom: 15px;
-            border-bottom: 1px solid #eee;
+            border-bottom: 1px solid var(--border-color); /* Updated */
             padding-bottom: 10px;
             font-size: 1.3em;
             font-weight: 600;
@@ -718,6 +906,9 @@
             max-width: 900px;
             border: 1px solid var(--border-color);
         }
+        body.dark-mode .chart-container, body.dark-mode #radarChartContainer {
+            /* Potential: Add specific dark mode styles for Plotly if needed, e.g., for text */
+        }
 
         .chart-div,
         #radarChart,
@@ -740,13 +931,16 @@
             border-left-color: var(--danger-color);
             color: var(--danger-color);
         }
+        body.dark-mode .error-message {
+            color: var(--danger-color-dark);
+        }
 
         .details-wrapper {
             margin-top: 30px;
             margin-bottom: 20px;
-            border: 1px solid #aaa;
+            border: 1px solid var(--details-border); /* Updated */
             border-radius: 5px;
-            background-color: #fff;
+            background-color: var(--card-bg); /* Updated */
             box-shadow: 0 3px 5px rgba(0, 0, 0, 0.07);
         }
 
@@ -756,7 +950,7 @@
             font-size: 1.1em;
             padding: 10px 15px;
             background-color: var(--header-bg);
-            border-bottom: 1px solid #aaa;
+            border-bottom: 1px solid var(--details-border); /* Updated */
             border-top-left-radius: 5px;
             border-top-right-radius: 5px;
             list-style: none;
@@ -781,18 +975,22 @@
 
         details summary:focus {
             outline: none;
-            box-shadow: 0 0 0 2px rgba(0, 123, 255, 0.25);
+            box-shadow: 0 0 0 2px rgba(0, 123, 255, 0.25); /* Needs theming if focus style is important */
         }
+        body.dark-mode details summary:focus {
+             box-shadow: 0 0 0 2px rgba(var(--primary-color-dark-rgb, 13, 110, 253), 0.35); /* Example for dark */
+        }
+
 
         details .details-content {
             padding: 20px;
-            border-top: 1px solid #eee;
+            border-top: 1px solid var(--details-content-border); /* Updated */
         }
 
         details .details-content h3 {
             margin-top: 1.5em;
             margin-bottom: 0.8em;
-            border-bottom: 1px dotted #ccc;
+            border-bottom: 1px dotted var(--border-color); /* Updated */
             padding-bottom: 4px;
             font-size: 1.1em;
         }
@@ -805,7 +1003,7 @@
             border: 1px solid var(--border-color);
             padding: 15px;
             margin-bottom: 25px;
-            background-color: #fdfdfd;
+            background-color: var(--carousel-bg); /* Updated */
             border-radius: 5px;
             box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
         }
@@ -814,12 +1012,12 @@
             text-align: center;
             margin-bottom: 10px;
             padding-bottom: 5px;
-            border-bottom: 1px solid #eee;
+            border-bottom: 1px solid var(--border-color); /* Updated */
         }
 
         .carousel-header h4 {
             margin: 0;
-            color: #555;
+            color: var(--carousel-header-text); /* Updated */
             font-size: 1.1em;
             border-bottom: none;
         }
@@ -838,14 +1036,14 @@
             margin-top: 0;
             margin-bottom: 10px;
             font-size: 1.15em;
-            color: #333;
+            color: var(--carousel-slide-text); /* Updated */
         }
 
         .carousel-nav {
             text-align: center;
             margin-top: 15px;
             padding-top: 10px;
-            border-top: 1px solid #eee;
+            border-top: 1px solid var(--border-color); /* Updated */
         }
 
         .carousel-nav button {
@@ -859,13 +1057,17 @@
             font-size: 0.95em;
             transition: background-color 0.2s ease;
         }
+        body.dark-mode .carousel-nav button { /* Ensure button text is white on dark primary */
+             color: #fff;
+        }
+
 
         .carousel-nav button:hover {
             background-color: var(--primary-hover);
         }
 
         .carousel-nav button:disabled {
-            background-color: #ccc;
+            background-color: var(--carousel-nav-disabled-bg); /* Updated */
             cursor: not-allowed;
             opacity: 0.7;
         }
@@ -882,10 +1084,10 @@
         }
 
         .group-overview-item {
-            border: 1px solid #e0e0e0;
+            border: 1px solid var(--group-overview-item-border); /* Updated */
             padding: 10px 15px;
             border-radius: 5px;
-            background-color: #fff;
+            background-color: var(--group-overview-item-bg); /* Updated */
             box-shadow: 0 1px 3px rgba(0, 0, 0, 0.04);
         }
 
@@ -894,9 +1096,9 @@
             margin-bottom: 10px;
             text-align: center;
             font-size: 1.1em;
-            border-bottom: 1px solid #eee;
+            border-bottom: 1px solid var(--border-color); /* Updated */
             padding-bottom: 5px;
-            color: #333;
+            color: var(--text-color); /* Updated */
         }
 
         .group-teams-table {
@@ -912,15 +1114,15 @@
             font-weight: 600;
             text-align: left;
             padding: 6px 8px;
-            color: #444;
+            color: var(--group-teams-table-header-text); /* Updated */
             border: none;
-            border-bottom: 1px solid #eee;
+            border-bottom: 1px solid var(--border-color); /* Updated */
         }
 
         .group-teams-table td {
             padding: 6px 8px;
             border: none;
-            border-bottom: 1px solid #f0f0f0;
+            border-bottom: 1px solid var(--group-teams-table-row-border); /* Updated */
             text-align: left;
         }
 
@@ -951,11 +1153,16 @@
             overflow-x: auto;
         }
 
-        .sticky-top {
+        .sticky-top { /* For table headers */
             position: sticky;
-            top: 0;
-            z-index: 100;
+            top: 0; /* Adjust if body has padding-top and nav is fixed */
+            z-index: 100; /* Check against nav-bar z-index */
+            background-color: var(--header-bg); /* Ensure header is visible on scroll */
         }
+        body.dark-mode .sticky-top {
+             background-color: var(--header-bg-dark);
+        }
+
 
         hr {
             border: none;
@@ -999,41 +1206,48 @@
 
         @media (max-width: 768px) {
             body {
-                padding-top: 60px;
+                /* padding-top: 60px; */ /* Value might need adjustment based on final nav height */
             }
 
             .nav-bar {
-                padding: 5px 15px;
+                padding: 5px 15px; /* Reduced padding */
+                /* flex-wrap: wrap; /* Already set */
             }
 
             .nav-title {
-                flex-grow: 0;
-                margin-right: auto;
+                flex-grow: 0; /* Don't allow title to push toggle too far */
+                margin-right: auto; /* Push other items to the right */
             }
 
-            .nav-toggle {
+            .nav-toggle { /* Hamburger menu toggle */
                 display: block;
-                flex-shrink: 0;
-                margin-left: 10px;
+                flex-shrink: 0; /* Prevent shrinking */
+                margin-left: 10px; /* Space from title */
+                order: 2; /* Comes after title, before dark mode toggle if it's also last */
+            }
+            
+            #darkModeToggle { /* Adjust dark mode toggle for mobile */
+                order: 3; /* After nav-toggle */
+                margin-left: 10px; /* Space from nav-toggle */
             }
 
             .nav-links {
-                display: none;
+                display: none; /* Hidden by default, JS toggles to flex */
                 flex-direction: column;
                 width: 100%;
                 align-items: flex-start;
-                background-color: white;
+                background-color: var(--nav-bar-bg); /* Use variable */
                 padding-top: 10px;
                 padding-bottom: 10px;
                 box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
                 position: absolute;
-                top: 100%;
+                top: 100%; /* Position below the nav-bar */
                 left: 0;
                 right: 0;
-                order: 3;
+                order: 4; /* Display below all other nav items */
             }
 
-            .nav-links.active {
+            .nav-links.active { /* When JS makes it active */
                 display: flex;
             }
 
@@ -1052,15 +1266,25 @@
 
             .nav-links a:hover,
             .nav-links a.active {
-                background-color: var(--light-bg);
+                background-color: var(--light-bg); /* Use variable */
                 color: var(--primary-hover);
-                border-bottom-color: var(--border-color);
+                border-bottom-color: var(--border-color); /* Keep consistent or use primary-hover */
             }
+            body.dark-mode .nav-links a:hover, body.dark-mode .nav-links a.active {
+                 background-color: var(--light-bg-dark);
+                 color: var(--primary-hover-dark);
+                 border-bottom-color: var(--border-color-dark);
+            }
+
 
             .nav-links a.active {
                 font-weight: 600;
-                border-bottom-color: var(--primary-hover);
+                border-bottom-color: var(--primary-hover); /* Active link highlight */
             }
+            body.dark-mode .nav-links a.active {
+                border-bottom-color: var(--primary-hover-dark);
+            }
+
 
             .container {
                 padding: 15px;
@@ -1129,9 +1353,9 @@
 <nav class="nav-bar">
     <div class="nav-title">Euro Simulátor</div>
     <button class="nav-toggle" id="navToggle" aria-label="Toggle navigation">
-        &#9776; 
+        &#9776; <!-- Hamburger icon -->
     </button>
-    <div class="nav-links" id="navLinks"> 
+    <div class="nav-links" id="navLinks">
         <a href="{{ url_for('index') }}" class="{{ 'active' if active_page == 'index' }}">Hlavní stránka</a>
         <a href="{{ url_for('simulation_results') }}" class="{{ 'active' if active_page == 'simulation' }}">Výsledky Simulace</a>
         <a href="{{ url_for('descriptive_analysis') }}" class="{{ 'active' if active_page == 'analysis' }}">Týmová Analýza</a>
@@ -1139,6 +1363,7 @@
         <a href="{{ url_for('attribute_distributions') }}" class="{{ 'active' if active_page == 'distributions' }}">Distribuce Atributů</a>
         <a href="{{ url_for('correlation_analysis') }}" class="{{ 'active' if active_page == 'correlation' }}">Korelační Analýza</a>
     </div>
+    <button id="darkModeToggle" aria-label="Toggle dark mode">🌙</button>
 </nav>
     <div class="container">
         <h1>{{ title }}</h1>
@@ -1718,6 +1943,103 @@
             }
 
         }); 
+
+    </script>
+    <script>
+        const toggleButton = document.getElementById('darkModeToggle');
+        const body = document.body;
+
+        // Function to apply the saved theme and update button text/icon
+        function applyTheme(theme) {
+            if (theme === 'dark') {
+                body.classList.add('dark-mode');
+                toggleButton.textContent = '☀️'; // Sun icon for light mode
+                toggleButton.setAttribute('aria-label', 'Switch to Light Mode');
+                // Update Plotly charts to dark theme if they exist
+                if (typeof Plotly !== 'undefined') {
+                    document.querySelectorAll('.chart-div, .chart').forEach(chartElement => {
+                        if (chartElement.layout) { // Check if it's a Plotly chart
+                            Plotly.relayout(chartElement, {
+                                'plot_bgcolor': 'var(--card-bg-dark)',
+                                'paper_bgcolor': 'var(--card-bg-dark)',
+                                'font.color': 'var(--text-color-dark)',
+                                'xaxis.color': 'var(--text-muted-dark)',
+                                'yaxis.color': 'var(--text-muted-dark)',
+                                'xaxis.gridcolor': 'var(--border-color-dark)',
+                                'yaxis.gridcolor': 'var(--border-color-dark)',
+                                'legend.bgcolor': 'var(--card-bg-dark)',
+                                'legend.bordercolor': 'var(--border-color-dark)',
+                            });
+                        }
+                    });
+                }
+            } else {
+                body.classList.remove('dark-mode');
+                toggleButton.textContent = '🌙'; // Moon icon for dark mode
+                toggleButton.setAttribute('aria-label', 'Switch to Dark Mode');
+                // Update Plotly charts to light theme
+                if (typeof Plotly !== 'undefined') {
+                    document.querySelectorAll('.chart-div, .chart').forEach(chartElement => {
+                        if (chartElement.layout) { // Check if it's a Plotly chart
+                            Plotly.relayout(chartElement, {
+                                'plot_bgcolor': 'var(--card-bg-light)',
+                                'paper_bgcolor': 'var(--card-bg-light)',
+                                'font.color': 'var(--text-color-light)',
+                                'xaxis.color': 'var(--text-muted-light)',
+                                'yaxis.color': 'var(--text-muted-light)',
+                                'xaxis.gridcolor': 'var(--border-color-light)',
+                                'yaxis.gridcolor': 'var(--border-color-light)',
+                                'legend.bgcolor': 'var(--card-bg-light)',
+                                'legend.bordercolor': 'var(--border-color-light)',
+                            });
+                        }
+                    });
+                }
+            }
+        }
+
+        // Load saved theme from localStorage
+        let savedTheme = localStorage.getItem('theme');
+
+        // Check for system preference if no theme is saved
+        if (!savedTheme) {
+            if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+                savedTheme = 'dark';
+            } else {
+                savedTheme = 'light'; // Default to light if no system preference or saved theme
+            }
+        }
+        
+        applyTheme(savedTheme); // Apply the determined theme
+
+        toggleButton.addEventListener('click', () => {
+            const currentTheme = body.classList.contains('dark-mode') ? 'dark' : 'light';
+            const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
+            applyTheme(newTheme);
+            localStorage.setItem('theme', newTheme);
+            localStorage.setItem('theme_manual_override', 'true'); // User made a choice
+        });
+
+        // Listen for changes in system preference
+        window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', event => {
+            if (!localStorage.getItem('theme_manual_override')) { // Only if user hasn't set manually
+                 const newColorScheme = event.matches ? "dark" : "light";
+                 applyTheme(newColorScheme);
+                 localStorage.setItem('theme', newColorScheme);
+            }
+        });
+
+        // Ensure Plotly charts are updated after they are initially rendered
+        // This is a bit of a hack; ideally, Plotly's initial render would use CSS vars
+        // or Plotly's own theming would be more deeply integrated.
+        // We wait for a brief moment for charts to potentially render.
+        setTimeout(() => {
+            if (body.classList.contains('dark-mode')) {
+                 applyTheme('dark'); // Re-apply to catch charts rendered after initial load
+            } else {
+                 applyTheme('light');
+            }
+        }, 1000); // Adjust delay as needed
 
     </script>
 </body>

--- a/euro_simulator_app copy 14/app/templates/correlation_analysis.html
+++ b/euro_simulator_app copy 14/app/templates/correlation_analysis.html
@@ -10,24 +10,192 @@
 
     <style>
         :root {
-            --primary-color: #007bff;
-            --primary-hover: #0056b3;
-            --secondary-color: #6c757d;
-            --secondary-hover: #5a6268;
-            --light-bg: #f8f9fa;
-            --border-color: #dee2e6;
-            --text-color: #343a40;
-            --text-muted: #6c757d;
-            --card-bg: #ffffff;
-            --header-bg: #e9ecef;
-            --success-color: #28a745;
-            --danger-color: #dc3545;
-            --stat-better: #28a745;
-            --stat-worse: #dc3545;
-            --stat-max: #17a2b8;
-            --stat-min: #ffc107;
-            --link-color: #007bff;
-            --link-hover: #0056b3;
+            /* Light Theme Variables */
+            --primary-color-light: #007bff;
+            --primary-hover-light: #0056b3;
+            --secondary-color-light: #6c757d;
+            --secondary-hover-light: #5a6268;
+            --light-bg-light: #f8f9fa; /* Used for forms, odd table rows */
+            --body-bg-light: #f4f4f4; /* Main page background */
+            --border-color-light: #dee2e6;
+            --text-color-light: #343a40;
+            --text-muted-light: #6c757d;
+            --card-bg-light: #ffffff;
+            --header-bg-light: #e9ecef;
+            --success-color-light: #28a745;
+            --danger-color-light: #dc3545;
+            --danger-hover-light: #c82333;
+            --stat-better-light: #28a745;
+            --stat-worse-light: #dc3545;
+            --stat-max-light: #17a2b8; /* Typically info */
+            --stat-min-light: #ffc107; /* Typically warning */
+            --link-color-light: #007bff;
+            --link-hover-light: #0056b3;
+            --nav-bar-bg-light: #ffffff;
+            --select-arrow-color-light: '%236c757d'; /* #6c757d */
+            --table-hover-bg-light: #f1f1f1;
+            --details-border-light: #aaa;
+            --details-content-border-light: #eee;
+            --carousel-bg-light: #fdfdfd;
+            --carousel-header-text-light: #555;
+            --carousel-slide-text-light: #333;
+            --carousel-nav-disabled-bg-light: #ccc;
+            --group-overview-item-bg-light: #fff;
+            --group-overview-item-border-light: #e0e0e0;
+            --group-teams-table-header-text-light: #444;
+            --group-teams-table-row-border-light: #f0f0f0;
+            --th-sortable-hover-bg-light: #dde2e6;
+            --th-sortable-arrow-color-light: #333;
+            --qualifier-bg-light: #d4edda;
+            --checkbox-hover-bg-light: #e9ecef;
+            --checkbox-hover-border-light: #adb5bd;
+            --button-disabled-bg-light: #ccc;
+            --button-disabled-border-light: #bbb;
+            --button-disabled-text-light: #888;
+            --category-label-indeterminate-bg-light: #daf0FF;
+            --attribute-group-border-light: #ddd;
+            --box-shadow-light: rgba(0, 0, 0, 0.05);
+
+
+            /* Dark Theme Variables */
+            --primary-color-dark: #0d6efd;
+            --primary-hover-dark: #3385fd;
+            --secondary-color-dark: #5c636a;
+            --secondary-hover-dark: #494f54;
+            --light-bg-dark: #22272e; 
+            --body-bg-dark: #1c2128;  
+            --border-color-dark: #444c56;
+            --text-color-dark: #adbac7;
+            --text-muted-dark: #768390;
+            --card-bg-dark: #2d333b;
+            --header-bg-dark: #373e47;
+            --success-color-dark: #34c356; 
+            --danger-color-dark: #f85149;  
+            --danger-hover-dark: #fa3d35;
+            --stat-better-dark: #34c356;
+            --stat-worse-dark: #f85149;
+            --stat-max-dark: #2cbce0; 
+            --stat-min-dark: #ffca2c; 
+            --link-color-dark: #2c8cff;
+            --link-hover-dark: #57a3ff;
+            --nav-bar-bg-dark: #2d333b;
+            --select-arrow-color-dark: '%23adbac7'; 
+            --table-hover-bg-dark: #373e47;
+            --details-border-dark: #555c66;
+            --details-content-border-dark: #444c56;
+            --carousel-bg-dark: #282e36;
+            --carousel-header-text-dark: #aab5c1;
+            --carousel-slide-text-dark: #adbac7;
+            --carousel-nav-disabled-bg-dark: #444c56;
+            --group-overview-item-bg-dark: #2d333b;
+            --group-overview-item-border-dark: #444c56;
+            --group-teams-table-header-text-dark: #adbac7;
+            --group-teams-table-row-border-dark: #373e47;
+            --th-sortable-hover-bg-dark: #404853;
+            --th-sortable-arrow-color-dark: #adbac7;
+            --qualifier-bg-dark: #2a5a3a !important; 
+            --checkbox-hover-bg-dark: #373e47;
+            --checkbox-hover-border-dark: #5a6268;
+            --button-disabled-bg-dark: #444c56;
+            --button-disabled-border-dark: #555c66;
+            --button-disabled-text-dark: #768390;
+            --category-label-indeterminate-bg-dark: #2a4a6e; /* Darker blue for indeterminate */
+            --attribute-group-border-dark: var(--border-color-dark);
+            --box-shadow-dark: rgba(255, 255, 255, 0.05);
+
+
+            /* Default to Light Theme */
+            --primary-color: var(--primary-color-light);
+            --primary-hover: var(--primary-hover-light);
+            --secondary-color: var(--secondary-color-light);
+            --secondary-hover: var(--secondary-hover-light);
+            --light-bg: var(--light-bg-light);
+            --body-bg: var(--body-bg-light);
+            --border-color: var(--border-color-light);
+            --text-color: var(--text-color-light);
+            --text-muted: var(--text-muted-light);
+            --card-bg: var(--card-bg-light);
+            --header-bg: var(--header-bg-light);
+            --success-color: var(--success-color-light);
+            --danger-color: var(--danger-color-light);
+            --danger-hover: var(--danger-hover-light);
+            --stat-better: var(--stat-better-light);
+            --stat-worse: var(--stat-worse-light);
+            --stat-max: var(--stat-max-light);
+            --stat-min: var(--stat-min-light);
+            --link-color: var(--link-color-light);
+            --link-hover: var(--link-hover-light);
+            --nav-bar-bg: var(--nav-bar-bg-light);
+            --select-arrow-color: var(--select-arrow-color-light);
+            --table-hover-bg: var(--table-hover-bg-light);
+            --details-border: var(--details-border-light);
+            --details-content-border: var(--details-content-border-light);
+            --carousel-bg: var(--carousel-bg-light);
+            --carousel-header-text: var(--carousel-header-text-light);
+            --carousel-slide-text: var(--carousel-slide-text-light);
+            --carousel-nav-disabled-bg: var(--carousel-nav-disabled-bg-light);
+            --group-overview-item-bg: var(--group-overview-item-bg-light);
+            --group-overview-item-border: var(--group-overview-item-border-light);
+            --group-teams-table-header-text: var(--group-teams-table-header-text-light);
+            --group-teams-table-row-border: var(--group-teams-table-row-border-light);
+            --th-sortable-hover-bg: var(--th-sortable-hover-bg-light);
+            --th-sortable-arrow-color: var(--th-sortable-arrow-color-light);
+            --qualifier-bg: var(--qualifier-bg-light);
+            --checkbox-hover-bg: var(--checkbox-hover-bg-light);
+            --checkbox-hover-border: var(--checkbox-hover-border-light);
+            --button-disabled-bg: var(--button-disabled-bg-light);
+            --button-disabled-border: var(--button-disabled-border-light);
+            --button-disabled-text: var(--button-disabled-text-light);
+            --category-label-indeterminate-bg: var(--category-label-indeterminate-bg-light);
+            --attribute-group-border: var(--attribute-group-border-light);
+            --box-shadow: var(--box-shadow-light);
+        }
+
+        body.dark-mode {
+            --primary-color: var(--primary-color-dark);
+            --primary-hover: var(--primary-hover-dark);
+            --secondary-color: var(--secondary-color-dark);
+            --secondary-hover: var(--secondary-hover-dark);
+            --light-bg: var(--light-bg-dark);
+            --body-bg: var(--body-bg-dark);
+            --border-color: var(--border-color-dark);
+            --text-color: var(--text-color-dark);
+            --text-muted: var(--text-muted-dark);
+            --card-bg: var(--card-bg-dark);
+            --header-bg: var(--header-bg-dark);
+            --success-color: var(--success-color-dark);
+            --danger-color: var(--danger-color-dark);
+            --danger-hover: var(--danger-hover-dark);
+            --stat-better: var(--stat-better-dark);
+            --stat-worse: var(--stat-worse-dark);
+            --stat-max: var(--stat-max-dark);
+            --stat-min: var(--stat-min-dark);
+            --link-color: var(--link-color-dark);
+            --link-hover: var(--link-hover-dark);
+            --nav-bar-bg: var(--nav-bar-bg-dark);
+            --select-arrow-color: var(--select-arrow-color-dark);
+            --table-hover-bg: var(--table-hover-bg-dark);
+            --details-border: var(--details-border-dark);
+            --details-content-border: var(--details-content-border-dark);
+            --carousel-bg: var(--carousel-bg-dark);
+            --carousel-header-text: var(--carousel-header-text-dark);
+            --carousel-slide-text: var(--carousel-slide-text-dark);
+            --carousel-nav-disabled-bg: var(--carousel-nav-disabled-bg-dark);
+            --group-overview-item-bg: var(--group-overview-item-bg-dark);
+            --group-overview-item-border: var(--group-overview-item-border-dark);
+            --group-teams-table-header-text: var(--group-teams-table-header-text-dark);
+            --group-teams-table-row-border: var(--group-teams-table-row-border-dark);
+            --th-sortable-hover-bg: var(--th-sortable-hover-bg-dark);
+            --th-sortable-arrow-color: var(--th-sortable-arrow-color-dark);
+            --qualifier-bg: var(--qualifier-bg-dark);
+            --checkbox-hover-bg: var(--checkbox-hover-bg-dark);
+            --checkbox-hover-border: var(--checkbox-hover-border-dark);
+            --button-disabled-bg: var(--button-disabled-bg-dark);
+            --button-disabled-border: var(--button-disabled-border-dark);
+            --button-disabled-text: var(--button-disabled-text-dark);
+            --category-label-indeterminate-bg: var(--category-label-indeterminate-bg-dark);
+            --attribute-group-border: var(--attribute-group-border-dark);
+            --box-shadow: var(--box-shadow-dark);
         }
 
         body {
@@ -35,7 +203,7 @@
             margin: 0;
             padding: 20px;
             line-height: 1.6;
-            background-color: #f4f4f4;
+            background-color: var(--body-bg);
             color: var(--text-color);
             position: relative;
             padding-top: 80px;
@@ -47,7 +215,7 @@
             padding: 25px;
             background-color: var(--card-bg);
             border-radius: 8px;
-            box-shadow: 0 4px 8px rgba(0, 0, 0, 0.05);
+            box-shadow: 0 4px 8px var(--box-shadow);
         }
 
         h1,
@@ -102,8 +270,8 @@
             top: 0;
             left: 0;
             right: 0;
-            background-color: white;
-            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+            background-color: var(--nav-bar-bg);
+            box-shadow: 0 2px 4px var(--box-shadow);
             z-index: 1000;
             padding: 10px 25px;
             display: flex;
@@ -118,6 +286,21 @@
             font-size: 1.2em;
             color: var(--text-color);
             flex-grow: 1;
+        }
+        
+        #darkModeToggle { /* Style for the new button */
+            background-color: var(--secondary-color);
+            color: white;
+            border: none;
+            padding: 8px 12px;
+            border-radius: 6px;
+            cursor: pointer;
+            font-size: 0.9em;
+            margin-left: 15px; /* Space from nav links or toggle */
+            order: 3; /* Ensure it comes after nav-links if they wrap */
+        }
+        body.dark-mode #darkModeToggle {
+            background-color: var(--primary-color);
         }
 
         .nav-toggle {
@@ -177,6 +360,14 @@
             transition: all 0.2s ease;
             white-space: nowrap;
         }
+        button:disabled,
+        a.button-link:disabled {
+            background-color: var(--button-disabled-bg) !important;
+            border-color: var(--button-disabled-border) !important;
+            color: var(--button-disabled-text) !important;
+            cursor: not-allowed !important;
+            opacity: 0.65 !important;
+        }
 
         .btn-primary,
         button.main-submit {
@@ -184,10 +375,13 @@
             border-color: var(--primary-color);
             color: white;
         }
+        body.dark-mode .btn-primary, body.dark-mode button.main-submit {
+            color: #fff;
+        }
 
         .btn-primary:hover,
         button.main-submit:hover {
-            background-color: var (--primary-hover);
+            background-color: var(--primary-hover);
             border-color: var(--primary-hover);
             color: white;
             text-decoration: none;
@@ -199,6 +393,9 @@
             background-color: var(--secondary-color);
             border-color: var(--secondary-color);
             color: white;
+        }
+        body.dark-mode .btn-secondary, body.dark-mode a.reset-button, body.dark-mode a.back-button {
+            color: #fff;
         }
 
         .btn-secondary:hover,
@@ -219,7 +416,7 @@
             background-color: var(--light-bg);
             padding: 25px;
             border-radius: 8px;
-            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+            box-shadow: 0 2px 4px var(--box-shadow);
             margin-bottom: 30px;
             border: 1px solid var(--border-color);
         }
@@ -283,15 +480,21 @@
 
         select {
             appearance: none;
-            background-image: url('data:image/svg+xml;charset=US-ASCII,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22292.4%22%20height%3D%22292.4%22%3E%3Cpath%20fill%3D%22%236c757d%22%20d%3D%22M287%2069.4a17.6%2017.6%200%200%200-13-5.4H18.4c-5%200-9.3%201.8-12.9%205.4A17.6%2017.6%200%200%200%200%2082.2c0%205%201.8%209.3%205.4%2012.9l128%20127.9c3.6%203.6%207.8%205.4%2012.8%205.4s9.2-1.8%2012.8-5.4L287%2095c3.6-3.6%205.4-7.8%205.4-12.8%200-5-1.8-9.2-5.4-12.8z%22%2F%3E%3C%2Fsvg%3E');
+            background-image: url('data:image/svg+xml;charset=US-ASCII,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22292.4%22%20height%3D%22292.4%22%3E%3Cpath%20fill%3D%22' + var(--select-arrow-color) + '%22%20d%3D%22M287%2069.4a17.6%2017.6%200%200%200-13-5.4H18.4c-5%200-9.3%201.8-12.9%205.4A17.6%2017.6%200%200%200%200%2082.2c0%205%201.8%209.3%205.4%2012.9l128%20127.9c3.6%203.6%207.8%205.4%2012.8%205.4s9.2-1.8%2012.8-5.4L287%2095c3.6-3.6%205.4-7.8%205.4-12.8%200-5-1.8-9.2-5.4-12.8z%22%2F%3E%3C%2Fsvg%3E');
             background-repeat: no-repeat;
             background-position: right 12px center;
             background-size: 10px 10px;
             padding-right: 35px;
         }
+        body:not(.dark-mode) select {
+             background-image: url('data:image/svg+xml;charset=US-ASCII,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22292.4%22%20height%3D%22292.4%22%3E%3Cpath%20fill%3D%22%236c757d%22%20d%3D%22M287%2069.4a17.6%2017.6%200%200%200-13-5.4H18.4c-5%200-9.3%201.8-12.9%205.4A17.6%2017.6%200%200%200%200%2082.2c0%205%201.8%209.3%205.4%2012.9l128%20127.9c3.6%203.6%207.8%205.4%2012.8%205.4s9.2-1.8%2012.8-5.4L287%2095c3.6-3.6%205.4-7.8%205.4-12.8%200-5-1.8-9.2-5.4-12.8z%22%2F%3E%3C%2Fsvg%3E');
+        }
+        body.dark-mode select {
+            background-image: url('data:image/svg+xml;charset=US-ASCII,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22292.4%22%20height%3D%22292.4%22%3E%3Cpath%20fill%3D%22%23adbac7%22%20d%3D%22M287%2069.4a17.6%2017.6%200%200%200-13-5.4H18.4c-5%200-9.3%201.8-12.9%205.4A17.6%2017.6%200%200%200%200%2082.2c0%205%201.8%209.3%205.4%2012.9l128%20127.9c3.6%203.6%207.8%205.4%2012.8%205.4s9.2-1.8%2012.8-5.4L287%2095c3.6-3.6%205.4-7.8%205.4-12.8%200-5-1.8-9.2-5.4-12.8z%22%2F%3E%3C%2Fsvg%3E');
+        }
 
         select:disabled {
-            background-color: #e9ecef;
+            background-color: var(--header-bg);
             cursor: not-allowed;
             opacity: 0.7;
         }
@@ -315,7 +518,7 @@
             margin-bottom: 10px;
         }
 
-        .checkbox-group {
+        .checkbox-group { /* For specific attribute/position checkboxes */
             display: flex;
             flex-wrap: wrap;
             gap: 8px 12px;
@@ -326,12 +529,12 @@
             display: none;
         }
 
-        .checkbox-group label,
+        .checkbox-group label, /* For specific attribute/position checkboxes */
         .radio-group label.radio-label {
             display: inline-block;
             padding: 6px 14px;
             border: 1px solid var(--border-color);
-            border-radius: 18px;
+            border-radius: 18px; /* Pill shape for checkboxes */
             background-color: var(--card-bg);
             color: var(--text-muted);
             cursor: pointer;
@@ -344,23 +547,28 @@
             text-align: center;
         }
 
-        .radio-group label.radio-label {
+        .radio-group label.radio-label { /* Radio buttons are not pills */
             border-radius: 6px;
             padding: 8px 12px;
             flex-grow: 1;
         }
 
-        .radio-group input[type="radio"]:checked+label.radio-label {
-            background-color: var(--primary-color);
-            color: white;
-            border-color: var(--primary-hover);
-        }
-
-
+        .radio-group input[type="radio"]:checked+label.radio-label,
         .checkbox-group input[type="checkbox"]:checked+label {
             background-color: var(--primary-color);
             color: white;
             border-color: var(--primary-hover);
+        }
+        body.dark-mode .radio-group input[type="radio"]:checked+label.radio-label,
+        body.dark-mode .checkbox-group input[type="checkbox"]:checked+label {
+            color: #fff;
+        }
+
+        .checkbox-group input[type="checkbox"]:not(:checked)+label:hover,
+        .radio-group input[type="radio"]:not(:checked)+label.radio-label:hover {
+            background-color: var(--checkbox-hover-bg);
+            border-color: var(--checkbox-hover-border);
+            color: var(--text-color);
         }
 
         .selection-buttons {
@@ -375,7 +583,7 @@
             width: 100%;
             margin: 20px auto 30px auto;
             background-color: var(--card-bg);
-            box-shadow: 0 2px 5px rgba(0, 0, 0, 0.07);
+            box-shadow: 0 2px 5px var(--box-shadow);
             border-radius: 8px;
             overflow: hidden;
             border: 1px solid var(--border-color);
@@ -408,7 +616,7 @@
         }
 
         tbody tr:hover {
-            background-color: #f1f1f1;
+            background-color: var(--table-hover-bg);
         }
 
         td.number,
@@ -427,7 +635,7 @@
         }
 
         th.sortable:hover {
-            background-color: #dde2e6;
+            background-color: var(--th-sortable-hover-bg);
         }
 
         th.sortable::after {
@@ -441,12 +649,12 @@
         }
 
         th.sortable.sort-asc::after {
-            border-bottom-color: #333;
+            border-bottom-color: var(--th-sortable-arrow-color);
             opacity: 1;
         }
 
         th.sortable.sort-desc::after {
-            border-top-color: #333;
+            border-top-color: var(--th-sortable-arrow-color);
             opacity: 1;
         }
 
@@ -487,7 +695,7 @@
             background-color: var(--card-bg);
             padding: 20px;
             border-radius: 8px;
-            box-shadow: 0 4px 8px rgba(0, 0, 0, 0.05);
+            box-shadow: 0 4px 8px var(--box-shadow);
             margin: 30px auto;
             max-width: 900px;
             border: 1px solid var(--border-color);
@@ -518,13 +726,16 @@
             border-left-color: var(--danger-color);
             color: var(--danger-color);
         }
+         body.dark-mode .error-message {
+            color: var(--danger-color-dark);
+        }
 
         .attribute-group {
-            border: 1px solid #ddd;
+            border: 1px solid var(--attribute-group-border); /* Updated */
             border-radius: 5px;
             padding: 15px;
             margin-bottom: 15px;
-            background-color: white;
+            background-color: var(--card-bg); /* Updated */
         }
 
         .attribute-group-title {
@@ -539,14 +750,14 @@
             padding-right: 10px;
             border: 1px solid var(--border-color);
             border-radius: 6px;
-            background-color: white;
+            background-color: var(--card-bg); /* Updated */
         }
 
         .position-category-group {
             border: 1px solid var(--border-color);
             border-radius: 5px;
             margin-bottom: 10px;
-            background-color: white;
+            background-color: var(--card-bg); /* Updated */
             overflow: hidden;
         }
 
@@ -576,7 +787,7 @@
             display: none;
         }
 
-        label.category-label {
+        label.category-label { /* General category label for positions and attributes */
             display: inline-block;
             padding: 8px 16px;
             border: 1px solid var(--border-color);
@@ -594,40 +805,27 @@
 
         .position-category-checkbox:not(:checked)+label.category-label:hover,
         .attribute-category-checkbox:not(:checked)+label.category-label:hover {
-            background-color: #dde2e6;
-            border-color: #adb5bd;
+            background-color: var(--checkbox-hover-bg) !important; /* Use variable, !important for specificity */
+            border-color: var(--checkbox-hover-border) !important; /* Use variable, !important for specificity */
         }
 
-        label.category-label.category-label-checked {
-            background-color: var(--primary-color);
-            color: white;
-            border-color: var(--primary-hover);
-        }
-
-        label.category-label.category-label-indeterminate {
-            background-color: #daf0FF;
-            color: var(--primary-hover);
-            border-color: var(--primary-color);
-        }
-
-        label.category-label.category-label-checked {
+        label.category-label.category-label-checked { /* JS controlled, for checked state */
             background-color: var(--primary-color) !important;
             color: white !important;
             border-color: var(--primary-hover) !important;
         }
+        body.dark-mode label.category-label.category-label-checked {
+            color: #fff !important;
+        }
 
-        label.category-label.category-label-indeterminate {
-            background-color: #daf0FF !important;
-            color: var (--primary-hover) !important;
+        label.category-label.category-label-indeterminate { /* JS controlled, for indeterminate state */
+            background-color: var(--category-label-indeterminate-bg) !important; /* Updated */
+            color: var(--primary-hover) !important; /* This might need adjustment for dark mode */
             border-color: var(--primary-color) !important;
         }
-
-        .position-category-checkbox:not(:checked)+label.category-label:hover,
-        .attribute-category-checkbox:not(:checked)+label.category-label:hover {
-            background-color: #dde2e6 !important;
-            border-color: #adb5bd !important;
+        body.dark-mode label.category-label.category-label-indeterminate {
+             color: var(--primary-hover-dark) !important;
         }
-
 
         .submit-container {
             text-align: center;
@@ -638,7 +836,7 @@
 
         @media (max-width: 768px) {
             body {
-                padding-top: 60px;
+                /* padding-top: 60px; */ /* Adjusted by nav-bar height */
             }
 
             .nav-bar {
@@ -654,6 +852,11 @@
                 display: block;
                 flex-shrink: 0;
                 margin-left: 10px;
+                order: 2;
+            }
+            #darkModeToggle {
+                order: 3;
+                margin-left: 10px;
             }
 
             .nav-links {
@@ -661,15 +864,15 @@
                 flex-direction: column;
                 width: 100%;
                 align-items: flex-start;
-                background-color: white;
+                background-color: var(--nav-bar-bg);
                 padding-top: 10px;
                 padding-bottom: 10px;
-                box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+                box-shadow: 0 4px 6px var(--box-shadow);
                 position: absolute;
                 top: 100%;
                 left: 0;
                 right: 0;
-                order: 3;
+                order: 4;
             }
 
             .nav-links.active {
@@ -695,11 +898,20 @@
                 color: var(--primary-hover);
                 border-bottom-color: var(--border-color);
             }
+             body.dark-mode .nav-links a:hover, body.dark-mode .nav-links a.active {
+                 background-color: var(--light-bg-dark);
+                 color: var(--primary-hover-dark);
+                 border-bottom-color: var(--border-color-dark);
+            }
 
             .nav-links a.active {
                 font-weight: 600;
                 border-bottom-color: var(--primary-hover);
             }
+            body.dark-mode .nav-links a.active {
+                border-bottom-color: var(--primary-hover-dark);
+            }
+
 
             .container {
                 padding: 15px;
@@ -780,7 +992,7 @@
             position: sticky;
             left: 0;
             z-index: 2;
-            box-shadow: 2px 0 5px rgba(0, 0, 0, 0.05);
+            box-shadow: 2px 0 5px var(--box-shadow);
         }
 
         #players-table thead th {
@@ -809,33 +1021,30 @@
         }
 
         #players-table tbody tr:hover td {
-            background-color: #f1f1f1;
+            background-color: var(--table-hover-bg); /* Updated */
         }
 
+        /* Ensure non-first-child cells also get hover effect */
         #players-table tbody td:not(:first-child) {
-            background-color: var(--card-bg);
+             background-color: var(--card-bg); /* Default for non-sticky cells */
         }
-
         #players-table tbody tr:nth-child(odd) td:not(:first-child) {
             background-color: var(--light-bg);
         }
-
         #players-table tbody tr:hover td:not(:first-child) {
-            background-color: #f1f1f1;
+            background-color: var(--table-hover-bg);
         }
 
+        /* Ensure first-child (sticky) cells also get hover effect */
         #players-table tbody td:first-child {
-            background-color: var(--card-bg);
+            background-color: var(--card-bg); /* Default for sticky cells */
         }
-
         #players-table tbody tr:nth-child(odd) td:first-child {
             background-color: var(--light-bg);
         }
-
-        #players-table tbody tr:hover td:first-child {
-            background-color: #f1f1f1;
+         #players-table tbody tr:hover td:first-child {
+            background-color: var(--table-hover-bg);
         }
-
 
         #players-table thead th {
             position: sticky;
@@ -847,7 +1056,6 @@
         #players-table thead th:first-child {
             z-index: 4;
         }
-
 
         #correlation-chart {
             width: 100%;
@@ -866,7 +1074,8 @@
             }
         }
 
-        @media (max-width: 768px) {
+        /* Redundant media query, consolidate if needed */
+        /* @media (max-width: 768px) {
             #correlation-chart {
                 height: 450px;
                 min-height: 350px;
@@ -876,9 +1085,10 @@
                 padding: 5px;
                 margin: 10px auto;
             }
-        }
+        } */
 
-        @media (max-width: 768px) {
+        /* Redundant media query, consolidate if needed */
+        /* @media (max-width: 768px) {
             .nav-title {
                 flex-grow: 0;
                 margin-right: auto;
@@ -888,7 +1098,7 @@
                 display: block;
                 margin-left: 10px;
             }
-        }
+        } */
     </style>
     <script>
     });
@@ -899,9 +1109,9 @@
     <nav class="nav-bar">
         <div class="nav-title">Euro Simulátor</div>
         <button class="nav-toggle" id="navToggle" aria-label="Toggle navigation">
-            &#9776; 
+            &#9776; <!-- Hamburger icon -->
         </button>
-        <div class="nav-links" id="navLinks"> 
+        <div class="nav-links" id="navLinks">
             <a href="{{ url_for('index') }}" class="{{ 'active' if active_page == 'index' }}">Hlavní stránka</a>
             <a href="{{ url_for('simulation_results') }}" class="{{ 'active' if active_page == 'simulation' }}">Výsledky Simulace</a>
             <a href="{{ url_for('descriptive_analysis') }}" class="{{ 'active' if active_page == 'analysis' }}">Týmová Analýza</a>
@@ -909,6 +1119,7 @@
             <a href="{{ url_for('attribute_distributions') }}" class="{{ 'active' if active_page == 'distributions' }}">Distribuce Atributů</a>
             <a href="{{ url_for('correlation_analysis') }}" class="active">Korelační Analýza</a>
         </div>
+        <button id="darkModeToggle" aria-label="Toggle dark mode">🌙</button>
     </nav>
 
     <div class="container mt-4">
@@ -1109,19 +1320,19 @@
                                 <ul class="list-group" style="list-style-type: none; padding: 0;">
                                     <li style="display: flex; justify-content: space-between; padding: 10px; border-bottom: 1px solid var(--border-color); background-color: var(--light-bg);">
                                         <span>1.0 Perfektní pozitivní korelace</span>
-                                        <span style="background-color: var(--danger-color); color: white; padding: 2px 8px; border-radius: 12px; font-size: 0.8em;">Perfektní</span>
+                                        <span class="badge" style="background-color: var(--danger-color); color: white; font-size: 0.8em;">Perfektní</span>
                                     </li>
                                     <li style="display: flex; justify-content: space-between; padding: 10px; border-bottom: 1px solid var(--border-color);">
                                         <span>0.7 - 0.9 Silná pozitivní korelace</span>
-                                        <span style="background-color: var(--danger-color); color: white; padding: 2px 8px; border-radius: 12px; font-size: 0.8em;">Silná</span>
+                                        <span class="badge" style="background-color: var(--danger-color); color: white; font-size: 0.8em;">Silná</span>
                                     </li>
                                     <li style="display: flex; justify-content: space-between; padding: 10px; border-bottom: 1px solid var(--border-color); background-color: var(--light-bg);">
                                         <span>0.4 - 0.6 Střední pozitivní korelace</span>
-                                        <span style="background-color: var(--stat-min); color: white; padding: 2px 8px; border-radius: 12px; font-size: 0.8em;">Střední</span>
+                                        <span class="badge" style="background-color: var(--stat-min); color: white; font-size: 0.8em;">Střední</span>
                                     </li>
                                     <li style="display: flex; justify-content: space-between; padding: 10px; border-bottom: 1px solid var(--border-color);">
                                         <span>0.1 - 0.3 Slabá pozitivní korelace</span>
-                                        <span style="background-color: var(--stat-max); color: white; padding: 2px 8px; border-radius: 12px; font-size: 0.8em;">Slabá</span>
+                                        <span class="badge" style="background-color: var(--stat-max); color: white; font-size: 0.8em;">Slabá</span>
                                     </li>
                                 </ul>
                             </div>
@@ -1129,19 +1340,19 @@
                                 <ul class="list-group" style="list-style-type: none; padding: 0;">
                                     <li style="display: flex; justify-content: space-between; padding: 10px; border-bottom: 1px solid var(--border-color); background-color: var(--light-bg);">
                                         <span>0 Žádná korelace</span>
-                                        <span style="background-color: var(--secondary-color); color: white; padding: 2px 8px; border-radius: 12px; font-size: 0.8em;">Žádná</span>
+                                        <span class="badge" style="background-color: var(--secondary-color); color: white; font-size: 0.8em;">Žádná</span>
                                     </li>
                                     <li style="display: flex; justify-content: space-between; padding: 10px; border-bottom: 1px solid var(--border-color);">
                                         <span>-0.1 - -0.3 Slabá negativní korelace</span>
-                                        <span style="background-color: var(--stat-max); color: white; padding: 2px 8px; border-radius: 12px; font-size: 0.8em;">Slabá</span>
+                                        <span class="badge" style="background-color: var(--stat-max); color: white; font-size: 0.8em;">Slabá</span>
                                     </li>
                                     <li style="display: flex; justify-content: space-between; padding: 10px; border-bottom: 1px solid var(--border-color); background-color: var(--light-bg);">
                                         <span>-0.4 - -0.6 Střední negativní korelace</span>
-                                        <span style="background-color: var(--stat-min); color: white; padding: 2px 8px; border-radius: 12px; font-size: 0.8em;">Střední</span>
+                                        <span class="badge" style="background-color: var(--stat-min); color: white; font-size: 0.8em;">Střední</span>
                                     </li>
                                     <li style="display: flex; justify-content: space-between; padding: 10px; border-bottom: 1px solid var(--border-color);">
                                         <span>-0.7 - -1.0 Silná negativní korelace</span>
-                                        <span style="background-color: var(--danger-color); color: white; padding: 2px 8px; border-radius: 12px; font-size: 0.8em;">Silná</span>
+                                        <span class="badge" style="background-color: var(--danger-color); color: white; font-size: 0.8em;">Silná</span>
                                     </li>
                                 </ul>
                             </div>

--- a/euro_simulator_app copy 14/app/templates/descriptive_analysis.html
+++ b/euro_simulator_app copy 14/app/templates/descriptive_analysis.html
@@ -13,24 +13,200 @@
     <script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
     <style>
         :root {
-            --primary-color: #007bff;
-            --primary-hover: #0056b3;
-            --secondary-color: #6c757d;
-            --secondary-hover: #5a6268;
-            --light-bg: #f8f9fa;
-            --border-color: #dee2e6;
-            --text-color: #343a40;
-            --text-muted: #6c757d;
-            --card-bg: #ffffff;
-            --header-bg: #e9ecef;
-            --success-color: #28a745;
-            --danger-color: #dc3545;
-            --stat-better: #28a745;
-            --stat-worse: #dc3545;
-            --stat-max: #17a2b8;
-            --stat-min: #ffc107;
-            --link-color: #007bff;
-            --link-hover: #0056b3;
+            /* Light Theme Variables */
+            --primary-color-light: #007bff;
+            --primary-hover-light: #0056b3;
+            --secondary-color-light: #6c757d;
+            --secondary-hover-light: #5a6268;
+            --light-bg-light: #f8f9fa; 
+            --body-bg-light: #f4f4f4; 
+            --border-color-light: #dee2e6;
+            --text-color-light: #343a40;
+            --text-muted-light: #6c757d;
+            --card-bg-light: #ffffff;
+            --header-bg-light: #e9ecef;
+            --success-color-light: #28a745;
+            --danger-color-light: #dc3545;
+            --danger-hover-light: #c82333;
+            --stat-better-light: #28a745;
+            --stat-worse-light: #dc3545;
+            --stat-max-light: #17a2b8; 
+            --stat-min-light: #ffc107; 
+            --link-color-light: #007bff;
+            --link-hover-light: #0056b3;
+            --nav-bar-bg-light: #ffffff;
+            --select-arrow-color-light: '%236c757d'; 
+            --table-hover-bg-light: #f1f1f1;
+            --details-border-light: #aaa;
+            --details-content-border-light: #eee;
+            --carousel-bg-light: #fdfdfd;
+            --carousel-header-text-light: #555;
+            --carousel-slide-text-light: #333;
+            --carousel-nav-disabled-bg-light: #ccc;
+            --group-overview-item-bg-light: #fff;
+            --group-overview-item-border-light: #e0e0e0;
+            --group-teams-table-header-text-light: #444;
+            --group-teams-table-row-border-light: #f0f0f0;
+            --th-sortable-hover-bg-light: #dde2e6;
+            --th-sortable-arrow-color-light: #333;
+            --qualifier-bg-light: #d4edda;
+            --checkbox-hover-bg-light: #e9ecef;
+            --checkbox-hover-border-light: #adb5bd;
+            --button-disabled-bg-light: #ccc; /* Using #ccc for general disabled */
+            --button-disabled-border-light: #bbb;
+            --button-disabled-text-light: #888;
+            --category-label-indeterminate-bg-light: #daf0FF;
+            --attribute-group-border-light: #ddd;
+            --box-shadow-light: rgba(0, 0, 0, 0.05);
+            --scope-toggle-hover-bg-light: #e9ecef;
+            --scope-toggle-hover-border-light: #adb5bd;
+
+
+            /* Dark Theme Variables */
+            --primary-color-dark: #0d6efd;
+            --primary-hover-dark: #3385fd;
+            --secondary-color-dark: #5c636a;
+            --secondary-hover-dark: #494f54;
+            --light-bg-dark: #22272e; 
+            --body-bg-dark: #1c2128;  
+            --border-color-dark: #444c56;
+            --text-color-dark: #adbac7;
+            --text-muted-dark: #768390;
+            --card-bg-dark: #2d333b;
+            --header-bg-dark: #373e47;
+            --success-color-dark: #34c356; 
+            --danger-color-dark: #f85149;  
+            --danger-hover-dark: #fa3d35;
+            --stat-better-dark: #34c356;
+            --stat-worse-dark: #f85149;
+            --stat-max-dark: #2cbce0; 
+            --stat-min-dark: #ffca2c; 
+            --link-color-dark: #2c8cff;
+            --link-hover-dark: #57a3ff;
+            --nav-bar-bg-dark: #2d333b;
+            --select-arrow-color-dark: '%23adbac7'; 
+            --table-hover-bg-dark: #373e47;
+            --details-border-dark: #555c66;
+            --details-content-border-dark: #444c56;
+            --carousel-bg-dark: #282e36;
+            --carousel-header-text-dark: #aab5c1;
+            --carousel-slide-text-dark: #adbac7;
+            --carousel-nav-disabled-bg-dark: #444c56;
+            --group-overview-item-bg-dark: #2d333b;
+            --group-overview-item-border-dark: #444c56;
+            --group-teams-table-header-text-dark: #adbac7;
+            --group-teams-table-row-border-dark: #373e47;
+            --th-sortable-hover-bg-dark: #404853;
+            --th-sortable-arrow-color-dark: #adbac7;
+            --qualifier-bg-dark: #2a5a3a !important; 
+            --checkbox-hover-bg-dark: #373e47;
+            --checkbox-hover-border-dark: #5a6268;
+            --button-disabled-bg-dark: #444c56;
+            --button-disabled-border-dark: #555c66;
+            --button-disabled-text-dark: #768390;
+            --category-label-indeterminate-bg-dark: #2a4a6e; 
+            --attribute-group-border-dark: var(--border-color-dark);
+            --box-shadow-dark: rgba(0, 0, 0, 0.25); /* Darker shadow for dark mode */
+            --scope-toggle-hover-bg-dark: #373e47;
+            --scope-toggle-hover-border-dark: #5a6268;
+
+
+            /* Default to Light Theme */
+            --primary-color: var(--primary-color-light);
+            --primary-hover: var(--primary-hover-light);
+            --secondary-color: var(--secondary-color-light);
+            --secondary-hover: var(--secondary-hover-light);
+            --light-bg: var(--light-bg-light);
+            --body-bg: var(--body-bg-light);
+            --border-color: var(--border-color-light);
+            --text-color: var(--text-color-light);
+            --text-muted: var(--text-muted-light);
+            --card-bg: var(--card-bg-light);
+            --header-bg: var(--header-bg-light);
+            --success-color: var(--success-color-light);
+            --danger-color: var(--danger-color-light);
+            --danger-hover: var(--danger-hover-light);
+            --stat-better: var(--stat-better-light);
+            --stat-worse: var(--stat-worse-light);
+            --stat-max: var(--stat-max-light);
+            --stat-min: var(--stat-min-light);
+            --link-color: var(--link-color-light);
+            --link-hover: var(--link-hover-light);
+            --nav-bar-bg: var(--nav-bar-bg-light);
+            --select-arrow-color: var(--select-arrow-color-light);
+            --table-hover-bg: var(--table-hover-bg-light);
+            --details-border: var(--details-border-light);
+            --details-content-border: var(--details-content-border-light);
+            --carousel-bg: var(--carousel-bg-light);
+            --carousel-header-text: var(--carousel-header-text-light);
+            --carousel-slide-text: var(--carousel-slide-text-light);
+            --carousel-nav-disabled-bg: var(--carousel-nav-disabled-bg-light);
+            --group-overview-item-bg: var(--group-overview-item-bg-light);
+            --group-overview-item-border: var(--group-overview-item-border-light);
+            --group-teams-table-header-text: var(--group-teams-table-header-text-light);
+            --group-teams-table-row-border: var(--group-teams-table-row-border-light);
+            --th-sortable-hover-bg: var(--th-sortable-hover-bg-light);
+            --th-sortable-arrow-color: var(--th-sortable-arrow-color-light);
+            --qualifier-bg: var(--qualifier-bg-light);
+            --checkbox-hover-bg: var(--checkbox-hover-bg-light);
+            --checkbox-hover-border: var(--checkbox-hover-border-light);
+            --button-disabled-bg: var(--button-disabled-bg-light);
+            --button-disabled-border: var(--button-disabled-border-light);
+            --button-disabled-text: var(--button-disabled-text-light);
+            --category-label-indeterminate-bg: var(--category-label-indeterminate-bg-light);
+            --attribute-group-border: var(--attribute-group-border-light);
+            --box-shadow: var(--box-shadow-light);
+            --scope-toggle-hover-bg: var(--scope-toggle-hover-bg-light);
+            --scope-toggle-hover-border: var(--scope-toggle-hover-border-light);
+        }
+
+        body.dark-mode {
+            --primary-color: var(--primary-color-dark);
+            --primary-hover: var(--primary-hover-dark);
+            --secondary-color: var(--secondary-color-dark);
+            --secondary-hover: var(--secondary-hover-dark);
+            --light-bg: var(--light-bg-dark);
+            --body-bg: var(--body-bg-dark);
+            --border-color: var(--border-color-dark);
+            --text-color: var(--text-color-dark);
+            --text-muted: var(--text-muted-dark);
+            --card-bg: var(--card-bg-dark);
+            --header-bg: var(--header-bg-dark);
+            --success-color: var(--success-color-dark);
+            --danger-color: var(--danger-color-dark);
+            --danger-hover: var(--danger-hover-dark);
+            --stat-better: var(--stat-better-dark);
+            --stat-worse: var(--stat-worse-dark);
+            --stat-max: var(--stat-max-dark);
+            --stat-min: var(--stat-min-dark);
+            --link-color: var(--link-color-dark);
+            --link-hover: var(--link-hover-dark);
+            --nav-bar-bg: var(--nav-bar-bg-dark);
+            --select-arrow-color: var(--select-arrow-color-dark);
+            --table-hover-bg: var(--table-hover-bg-dark);
+            --details-border: var(--details-border-dark);
+            --details-content-border: var(--details-content-border-dark);
+            --carousel-bg: var(--carousel-bg-dark);
+            --carousel-header-text: var(--carousel-header-text-dark);
+            --carousel-slide-text: var(--carousel-slide-text-dark);
+            --carousel-nav-disabled-bg: var(--carousel-nav-disabled-bg-dark);
+            --group-overview-item-bg: var(--group-overview-item-bg-dark);
+            --group-overview-item-border: var(--group-overview-item-border-dark);
+            --group-teams-table-header-text: var(--group-teams-table-header-text-dark);
+            --group-teams-table-row-border: var(--group-teams-table-row-border-dark);
+            --th-sortable-hover-bg: var(--th-sortable-hover-bg-dark);
+            --th-sortable-arrow-color: var(--th-sortable-arrow-color-dark);
+            --qualifier-bg: var(--qualifier-bg-dark);
+            --checkbox-hover-bg: var(--checkbox-hover-bg-dark);
+            --checkbox-hover-border: var(--checkbox-hover-border-dark);
+            --button-disabled-bg: var(--button-disabled-bg-dark);
+            --button-disabled-border: var(--button-disabled-border-dark);
+            --button-disabled-text: var(--button-disabled-text-dark);
+            --category-label-indeterminate-bg: var(--category-label-indeterminate-bg-dark);
+            --attribute-group-border: var(--attribute-group-border-dark);
+            --box-shadow: var(--box-shadow-dark);
+            --scope-toggle-hover-bg: var(--scope-toggle-hover-bg-dark);
+            --scope-toggle-hover-border: var(--scope-toggle-hover-border-dark);
         }
 
         body {
@@ -38,7 +214,7 @@
             margin: 0;
             padding: 20px;
             line-height: 1.6;
-            background-color: #f4f4f4;
+            background-color: var(--body-bg);
             color: var(--text-color);
             position: relative;
             padding-top: 80px;
@@ -50,7 +226,7 @@
             padding: 25px;
             background-color: var(--card-bg);
             border-radius: 8px;
-            box-shadow: 0 4px 8px rgba(0, 0, 0, 0.05);
+            box-shadow: 0 4px 8px var(--box-shadow);
         }
 
         h1,
@@ -105,8 +281,8 @@
             top: 0;
             left: 0;
             right: 0;
-            background-color: white;
-            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+            background-color: var(--nav-bar-bg);
+            box-shadow: 0 2px 4px var(--box-shadow);
             z-index: 1000;
             padding: 10px 25px;
             display: flex;
@@ -121,6 +297,21 @@
             font-size: 1.2em;
             color: var(--text-color);
             flex-grow: 1;
+        }
+        
+        #darkModeToggle {
+            background-color: var(--secondary-color);
+            color: white;
+            border: none;
+            padding: 8px 12px;
+            border-radius: 6px;
+            cursor: pointer;
+            font-size: 0.9em;
+            margin-left: 15px; 
+            order: 3; 
+        }
+        body.dark-mode #darkModeToggle {
+            background-color: var(--primary-color);
         }
 
         .nav-toggle {
@@ -187,6 +378,9 @@
             border-color: var(--primary-color);
             color: white;
         }
+         body.dark-mode .btn-primary, body.dark-mode button.main-submit {
+            color: #fff;
+        }
 
         .btn-primary:hover,
         button.main-submit:hover {
@@ -198,8 +392,9 @@
 
         .btn-primary:disabled,
         button.main-submit:disabled {
-            background-color: var(--secondary-color);
-            border-color: var(--secondary-color);
+            background-color: var(--button-disabled-bg); /* Updated */
+            border-color: var(--button-disabled-border); /* Updated */
+            color: var(--button-disabled-text); /* Updated */
             opacity: 0.65;
             cursor: not-allowed;
         }
@@ -211,6 +406,10 @@
             border-color: var(--secondary-color);
             color: white;
         }
+        body.dark-mode .btn-secondary, body.dark-mode a.reset-button, body.dark-mode a.back-button {
+            color: #fff;
+        }
+
 
         .btn-secondary:hover,
         a.reset-button:hover,
@@ -230,7 +429,7 @@
             background-color: var(--light-bg);
             padding: 25px;
             border-radius: 8px;
-            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+            box-shadow: 0 2px 4px var(--box-shadow);
             margin-bottom: 30px;
             border: 1px solid var(--border-color);
         }
@@ -293,15 +492,21 @@
 
         select {
             appearance: none;
-            background-image: url('data:image/svg+xml;charset=US-ASCII,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22292.4%22%20height%3D%22292.4%22%3E%3Cpath%20fill%3D%22%236c757d%22%20d%3D%22M287%2069.4a17.6%2017.6%200%200%200-13-5.4H18.4c-5%200-9.3%201.8-12.9%205.4A17.6%2017.6%200%200%200%200%2082.2c0%205%201.8%209.3%205.4%2012.9l128%20127.9c3.6%203.6%207.8%205.4%2012.8%205.4s9.2-1.8%2012.8-5.4L287%2095c3.6-3.6%205.4-7.8%205.4-12.8%200-5-1.8-9.2-5.4-12.8z%22%2F%3E%3C%2Fsvg%3E');
+            background-image: url('data:image/svg+xml;charset=US-ASCII,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22292.4%22%20height%3D%22292.4%22%3E%3Cpath%20fill%3D%22' + var(--select-arrow-color) + '%22%20d%3D%22M287%2069.4a17.6%2017.6%200%200%200-13-5.4H18.4c-5%200-9.3%201.8-12.9%205.4A17.6%2017.6%200%200%200%200%2082.2c0%205%201.8%209.3%205.4%2012.9l128%20127.9c3.6%203.6%207.8%205.4%2012.8%205.4s9.2-1.8%2012.8-5.4L287%2095c3.6-3.6%205.4-7.8%205.4-12.8%200-5-1.8-9.2-5.4-12.8z%22%2F%3E%3C%2Fsvg%3E');
             background-repeat: no-repeat;
             background-position: right 12px center;
             background-size: 10px 10px;
             padding-right: 35px;
         }
+         body:not(.dark-mode) select {
+             background-image: url('data:image/svg+xml;charset=US-ASCII,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22292.4%22%20height%3D%22292.4%22%3E%3Cpath%20fill%3D%22%236c757d%22%20d%3D%22M287%2069.4a17.6%2017.6%200%200%200-13-5.4H18.4c-5%200-9.3%201.8-12.9%205.4A17.6%2017.6%200%200%200%200%2082.2c0%205%201.8%209.3%205.4%2012.9l128%20127.9c3.6%203.6%207.8%205.4%2012.8%205.4s9.2-1.8%2012.8-5.4L287%2095c3.6-3.6%205.4-7.8%205.4-12.8%200-5-1.8-9.2-5.4-12.8z%22%2F%3E%3C%2Fsvg%3E');
+        }
+        body.dark-mode select {
+            background-image: url('data:image/svg+xml;charset=US-ASCII,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22292.4%22%20height%3D%22292.4%22%3E%3Cpath%20fill%3D%22%23adbac7%22%20d%3D%22M287%2069.4a17.6%2017.6%200%200%200-13-5.4H18.4c-5%200-9.3%201.8-12.9%205.4A17.6%2017.6%200%200%200%200%2082.2c0%205%201.8%209.3%205.4%2012.9l128%20127.9c3.6%203.6%207.8%205.4%2012.8%205.4s9.2-1.8%2012.8-5.4L287%2095c3.6-3.6%205.4-7.8%205.4-12.8%200-5-1.8-9.2-5.4-12.8z%22%2F%3E%3C%2Fsvg%3E');
+        }
 
         select:disabled {
-            background-color: #e9ecef;
+            background-color: var(--header-bg); /* Updated */
             cursor: not-allowed;
             opacity: 0.7;
         }
@@ -364,17 +569,24 @@
             padding: 8px 12px;
         }
 
-        .radio-group input[type="radio"]:checked+label.radio-label {
-            background-color: var(--primary-color);
-            border-color: var(--primary-color);
-            color: white;
-        }
-
+        .radio-group input[type="radio"]:checked+label.radio-label,
         .checkbox-group input[type="checkbox"]:checked+label {
             background-color: var(--primary-color);
-            border-color: var(--primary-color);
+            border-color: var(--primary-color); /* Or primary-hover for consistency */
             color: white;
         }
+        body.dark-mode .radio-group input[type="radio"]:checked+label.radio-label,
+        body.dark-mode .checkbox-group input[type="checkbox"]:checked+label {
+            color: #fff;
+        }
+
+        .checkbox-group input[type="checkbox"]:not(:checked)+label:hover,
+        .radio-group input[type="radio"]:not(:checked)+label.radio-label:hover {
+            background-color: var(--checkbox-hover-bg);
+            border-color: var(--checkbox-hover-border);
+            color: var(--text-color);
+        }
+
 
         .selection-buttons {
             margin-bottom: 10px;
@@ -420,8 +632,8 @@
         }
 
         .attribute-category-checkbox:not(:checked)+label.category-label:hover {
-            background-color: #dde2e6;
-            border-color: #adb5bd;
+            background-color: var(--checkbox-hover-bg); /* Updated */
+            border-color: var(--checkbox-hover-border); /* Updated */
         }
 
         .attribute-category-checkbox:checked+label.category-label {
@@ -429,16 +641,22 @@
             color: white;
             border-color: var(--primary-hover);
         }
+         body.dark-mode .attribute-category-checkbox:checked+label.category-label {
+            color: #fff;
+        }
 
         label.category-label.category-label-indeterminate {
-            background-color: #daf0FF !important;
-            color: var(--primary-hover) !important;
+            background-color: var(--category-label-indeterminate-bg) !important; /* Updated */
+            color: var(--primary-hover) !important; /* Needs review for dark mode */
             border-color: var(--primary-color) !important;
+        }
+        body.dark-mode label.category-label.category-label-indeterminate {
+             color: var(--primary-hover-dark) !important;
         }
 
         .attribute-category-checkbox:not(:checked)+label.category-label:not(.category-label-indeterminate):hover {
-            background-color: #dde2e6;
-            border-color: #adb5bd;
+            background-color: var(--checkbox-hover-bg); /* Updated */
+            border-color: var(--checkbox-hover-border); /* Updated */
         }
 
         .attribute-specifics-container {
@@ -461,7 +679,7 @@
             width: 100%;
             margin: 20px auto 30px auto;
             background-color: var(--card-bg);
-            box-shadow: 0 2px 5px rgba(0, 0, 0, 0.07);
+            box-shadow: 0 2px 5px var(--box-shadow); /* Updated */
             border-radius: 8px;
             overflow: hidden;
             border: 1px solid var(--border-color);
@@ -494,7 +712,7 @@
         }
 
         tbody tr:hover {
-            background-color: #f1f1f1;
+            background-color: var(--table-hover-bg); /* Updated */
         }
 
         td.number,
@@ -513,7 +731,7 @@
         }
 
         th.sortable:hover {
-            background-color: #dde2e6;
+            background-color: var(--th-sortable-hover-bg); /* Updated */
         }
 
         th.sortable::after {
@@ -527,12 +745,12 @@
         }
 
         th.sortable.sort-asc::after {
-            border-bottom-color: #333;
+            border-bottom-color: var(--th-sortable-arrow-color); /* Updated */
             opacity: 1;
         }
 
         th.sortable.sort-desc::after {
-            border-top-color: #333;
+            border-top-color: var(--th-sortable-arrow-color); /* Updated */
             opacity: 1;
         }
 
@@ -584,14 +802,18 @@
         }
 
         tr.qualifier {
-            background-color: #d4edda !important;
+            background-color: var(--qualifier-bg) !important; /* Updated */
         }
+        body.dark-mode tr.qualifier td {
+            color: #e1e8ef; 
+        }
+
 
         .player-card {
             background-color: var(--card-bg);
             padding: 25px;
             border-radius: 8px;
-            box-shadow: 0 4px 8px rgba(0, 0, 0, 0.05);
+            box-shadow: 0 4px 8px var(--box-shadow); /* Updated */
             margin-bottom: 20px;
             border: 1px solid var(--border-color);
         }
@@ -614,7 +836,7 @@
         .player-card h2 {
             margin-top: 0;
             margin-bottom: 15px;
-            border-bottom: 1px solid #eee;
+            border-bottom: 1px solid var(--border-color); /* Updated */
             padding-bottom: 10px;
             font-size: 1.3em;
             font-weight: 600;
@@ -652,7 +874,7 @@
             background-color: var(--card-bg);
             padding: 20px;
             border-radius: 8px;
-            box-shadow: 0 4px 8px rgba(0, 0, 0, 0.05);
+            box-shadow: 0 4px 8px var(--box-shadow); /* Updated */
             margin: 30px auto;
             max-width: 900px;
             border: 1px solid var(--border-color);
@@ -679,14 +901,17 @@
             border-left-color: var(--danger-color);
             color: var(--danger-color);
         }
+        body.dark-mode .error-message {
+            color: var(--danger-color-dark);
+        }
 
         .details-wrapper {
             margin-top: 30px;
             margin-bottom: 20px;
-            border: 1px solid #aaa;
+            border: 1px solid var(--details-border); /* Updated */
             border-radius: 5px;
-            background-color: #fff;
-            box-shadow: 0 3px 5px rgba(0, 0, 0, 0.07);
+            background-color: var(--card-bg); /* Updated */
+            box-shadow: 0 3px 5px var(--box-shadow); /* Updated */
         }
 
         details summary {
@@ -695,7 +920,7 @@
             font-size: 1.1em;
             padding: 10px 15px;
             background-color: var(--header-bg);
-            border-bottom: 1px solid #aaa;
+            border-bottom: 1px solid var(--details-border); /* Updated */
             border-top-left-radius: 5px;
             border-top-right-radius: 5px;
             list-style: none;
@@ -720,18 +945,22 @@
 
         details summary:focus {
             outline: none;
-            box-shadow: 0 0 0 2px rgba(0, 123, 255, 0.25);
+            box-shadow: 0 0 0 2px rgba(0, 123, 255, 0.25); /* Needs theming */
         }
+        body.dark-mode details summary:focus {
+             box-shadow: 0 0 0 2px rgba(var(--primary-color-dark-rgb, 13, 110, 253), 0.35);
+        }
+
 
         details .details-content {
             padding: 20px;
-            border-top: 1px solid #eee;
+            border-top: 1px solid var(--details-content-border); /* Updated */
         }
 
         details .details-content h3 {
             margin-top: 1.5em;
             margin-bottom: 0.8em;
-            border-bottom: 1px dotted #ccc;
+            border-bottom: 1px dotted var(--border-color); /* Updated */
             padding-bottom: 4px;
             font-size: 1.1em;
         }
@@ -744,21 +973,21 @@
             border: 1px solid var(--border-color);
             padding: 15px;
             margin-bottom: 25px;
-            background-color: #fdfdfd;
+            background-color: var(--carousel-bg); /* Updated */
             border-radius: 5px;
-            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+            box-shadow: 0 2px 4px var(--box-shadow); /* Updated */
         }
 
         .carousel-header {
             text-align: center;
             margin-bottom: 10px;
             padding-bottom: 5px;
-            border-bottom: 1px solid #eee;
+            border-bottom: 1px solid var(--border-color); /* Updated */
         }
 
         .carousel-header h4 {
             margin: 0;
-            color: #555;
+            color: var(--carousel-header-text); /* Updated */
             font-size: 1.1em;
             border-bottom: none;
         }
@@ -777,14 +1006,14 @@
             margin-top: 0;
             margin-bottom: 10px;
             font-size: 1.15em;
-            color: #333;
+            color: var(--carousel-slide-text); /* Updated */
         }
 
         .carousel-nav {
             text-align: center;
             margin-top: 15px;
             padding-top: 10px;
-            border-top: 1px solid #eee;
+            border-top: 1px solid var(--border-color); /* Updated */
         }
 
         .carousel-nav button {
@@ -798,13 +1027,16 @@
             font-size: 0.95em;
             transition: background-color 0.2s ease;
         }
+        body.dark-mode .carousel-nav button {
+             color: #fff;
+        }
 
         .carousel-nav button:hover {
             background-color: var(--primary-hover);
         }
 
         .carousel-nav button:disabled {
-            background-color: #ccc;
+            background-color: var(--carousel-nav-disabled-bg); /* Updated */
             cursor: not-allowed;
             opacity: 0.7;
         }
@@ -821,11 +1053,11 @@
         }
 
         .group-overview-item {
-            border: 1px solid #e0e0e0;
+            border: 1px solid var(--group-overview-item-border); /* Updated */
             padding: 10px 15px;
             border-radius: 5px;
-            background-color: #fff;
-            box-shadow: 0 1px 3px rgba(0, 0, 0, 0.04);
+            background-color: var(--group-overview-item-bg); /* Updated */
+            box-shadow: 0 1px 3px var(--box-shadow); /* Updated */
         }
 
         .group-overview-item h4 {
@@ -833,9 +1065,9 @@
             margin-bottom: 10px;
             text-align: center;
             font-size: 1.1em;
-            border-bottom: 1px solid #eee;
+            border-bottom: 1px solid var(--border-color); /* Updated */
             padding-bottom: 5px;
-            color: #333;
+            color: var(--text-color); /* Updated */
         }
 
         .group-teams-table {
@@ -851,15 +1083,15 @@
             font-weight: 600;
             text-align: left;
             padding: 6px 8px;
-            color: #444;
+            color: var(--group-teams-table-header-text); /* Updated */
             border: none;
-            border-bottom: 1px solid #eee;
+            border-bottom: 1px solid var(--border-color); /* Updated */
         }
 
         .group-teams-table td {
             padding: 6px 8px;
             border: none;
-            border-bottom: 1px solid #f0f0f0;
+            border-bottom: 1px solid var(--group-teams-table-row-border); /* Updated */
             text-align: left;
         }
 
@@ -892,9 +1124,14 @@
 
         .sticky-top {
             position: sticky;
-            top: 0;
+            top: 0; 
             z-index: 100;
+            background-color: var(--header-bg); /* Ensure header is visible */
         }
+        body.dark-mode .sticky-top {
+             background-color: var(--header-bg-dark);
+        }
+
 
         hr {
             border: none;
@@ -945,10 +1182,14 @@
             border-color: var(--primary-color);
             z-index: 1;
         }
+         body.dark-mode .scope-toggle-container a.btn-primary {
+            color: #fff;
+        }
+
 
         .scope-toggle-container a.btn-secondary:hover {
-            background-color: #e9ecef;
-            border-color: #adb5bd;
+            background-color: var(--scope-toggle-hover-bg); /* Updated */
+            border-color: var(--scope-toggle-hover-border); /* Updated */
             color: var(--text-color);
             z-index: 2;
         }
@@ -988,7 +1229,7 @@
 
         @media (max-width: 768px) {
             body {
-                padding-top: 60px;
+                /* padding-top: 60px; */ /* Adjusted by nav-bar height */
             }
 
             .nav-bar {
@@ -1002,6 +1243,11 @@
 
             .nav-toggle {
                 display: block;
+                order: 2;
+            }
+            #darkModeToggle {
+                order: 3;
+                margin-left: 10px;
             }
 
             .nav-links {
@@ -1009,15 +1255,15 @@
                 flex-direction: column;
                 width: 100%;
                 align-items: flex-start;
-                background-color: white;
+                background-color: var(--nav-bar-bg); /* Updated */
                 padding-top: 10px;
                 padding-bottom: 10px;
-                box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+                box-shadow: 0 4px 6px var(--box-shadow); /* Updated */
                 position: absolute;
                 top: 100%;
                 left: 0;
                 right: 0;
-                order: 3;
+                order: 4; /* After title, nav-toggle, and dark mode toggle */
             }
 
             .nav-links.active {
@@ -1041,13 +1287,23 @@
             .nav-links a.active {
                 background-color: var(--light-bg);
                 color: var(--primary-hover);
-                border-bottom-color: var(--border-color);
+                border-bottom-color: var(--border-color); /* Or primary-hover */
             }
+            body.dark-mode .nav-links a:hover, body.dark-mode .nav-links a.active {
+                 background-color: var(--light-bg-dark);
+                 color: var(--primary-hover-dark);
+                 border-bottom-color: var(--border-color-dark);
+            }
+
 
             .nav-links a.active {
                 font-weight: 600;
                 border-bottom-color: var(--primary-hover);
             }
+             body.dark-mode .nav-links a.active {
+                border-bottom-color: var(--primary-hover-dark);
+            }
+
 
             .container {
                 padding: 15px;
@@ -1123,7 +1379,7 @@
         <button class="nav-toggle" id="navToggle" aria-label="Toggle navigation">
             &#9776;
         </button>
-        <div class="nav-links" id="navLinks"> 
+        <div class="nav-links" id="navLinks">
             <a href="{{ url_for('index') }}" class="{{ 'active' if active_page == 'index' }}">Hlavní stránka</a>
             <a href="{{ url_for('simulation_results') }}" class="{{ 'active' if active_page == 'simulation' }}">Výsledky
                 Simulace</a>
@@ -1136,6 +1392,7 @@
             <a href="{{ url_for('correlation_analysis') }}"
                 class="{{ 'active' if active_page == 'correlation' }}">Korelační Analýza</a>
         </div>
+        <button id="darkModeToggle" aria-label="Toggle dark mode">🌙</button>
     </nav>
     <div class="container">
         <h1>{{ title }}</h1>
@@ -1591,6 +1848,113 @@
 
         }); 
 
+    </script>
+    <script>
+        const toggleButton = document.getElementById('darkModeToggle');
+        const body = document.body;
+
+        // Function to apply the saved theme and update button text/icon
+        function applyTheme(theme) {
+            if (theme === 'dark') {
+                body.classList.add('dark-mode');
+                toggleButton.textContent = '☀️'; // Sun icon for light mode
+                toggleButton.setAttribute('aria-label', 'Switch to Light Mode');
+                 // Update Plotly charts to dark theme if they exist
+                if (typeof Plotly !== 'undefined') {
+                    document.querySelectorAll('.chart-div, .chart, #radarChartContainer').forEach(chartElement => {
+                        if (chartElement.layout) { // Check if it's a Plotly chart
+                            Plotly.relayout(chartElement, {
+                                'plot_bgcolor': 'var(--card-bg-dark)',
+                                'paper_bgcolor': 'var(--card-bg-dark)',
+                                'font.color': 'var(--text-color-dark)',
+                                'xaxis.color': 'var(--text-muted-dark)',
+                                'yaxis.color': 'var(--text-muted-dark)',
+                                'xaxis.gridcolor': 'var(--border-color-dark)',
+                                'yaxis.gridcolor': 'var(--border-color-dark)',
+                                'legend.bgcolor': 'var(--card-bg-dark)',
+                                'legend.bordercolor': 'var(--border-color-dark)',
+                                // For radar charts specifically
+                                'polar.bgcolor': 'var(--card-bg-dark)',
+                                'polar.angularaxis.gridcolor': 'var(--border-color-dark)',
+                                'polar.radialaxis.gridcolor': 'var(--border-color-dark)',
+                                'polar.angularaxis.linecolor': 'var(--border-color-dark)',
+                                'polar.radialaxis.linecolor': 'var(--border-color-dark)',
+                                'polar.angularaxis.tickcolor': 'var(--text-muted-dark)',
+                                'polar.radialaxis.tickcolor': 'var(--text-muted-dark)',
+                            });
+                        }
+                    });
+                }
+            } else {
+                body.classList.remove('dark-mode');
+                toggleButton.textContent = '🌙'; // Moon icon for dark mode
+                toggleButton.setAttribute('aria-label', 'Switch to Dark Mode');
+                // Update Plotly charts to light theme
+                if (typeof Plotly !== 'undefined') {
+                    document.querySelectorAll('.chart-div, .chart, #radarChartContainer').forEach(chartElement => {
+                        if (chartElement.layout) { // Check if it's a Plotly chart
+                            Plotly.relayout(chartElement, {
+                                'plot_bgcolor': 'var(--card-bg-light)',
+                                'paper_bgcolor': 'var(--card-bg-light)',
+                                'font.color': 'var(--text-color-light)',
+                                'xaxis.color': 'var(--text-muted-light)',
+                                'yaxis.color': 'var(--text-muted-light)',
+                                'xaxis.gridcolor': 'var(--border-color-light)',
+                                'yaxis.gridcolor': 'var(--border-color-light)',
+                                'legend.bgcolor': 'var(--card-bg-light)',
+                                'legend.bordercolor': 'var(--border-color-light)',
+                                // For radar charts specifically
+                                'polar.bgcolor': 'var(--card-bg-light)',
+                                'polar.angularaxis.gridcolor': 'var(--border-color-light)',
+                                'polar.radialaxis.gridcolor': 'var(--border-color-light)',
+                                'polar.angularaxis.linecolor': 'var(--border-color-light)',
+                                'polar.radialaxis.linecolor': 'var(--border-color-light)',
+                                'polar.angularaxis.tickcolor': 'var(--text-muted-light)',
+                                'polar.radialaxis.tickcolor': 'var(--text-muted-light)',
+                            });
+                        }
+                    });
+                }
+            }
+        }
+
+        // Load saved theme from localStorage
+        let savedTheme = localStorage.getItem('theme');
+
+        // Check for system preference if no theme is saved
+        if (!savedTheme) {
+            if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+                savedTheme = 'dark';
+            } else {
+                savedTheme = 'light'; 
+            }
+        }
+        
+        applyTheme(savedTheme); 
+
+        toggleButton.addEventListener('click', () => {
+            const currentTheme = body.classList.contains('dark-mode') ? 'dark' : 'light';
+            const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
+            applyTheme(newTheme);
+            localStorage.setItem('theme', newTheme);
+            localStorage.setItem('theme_manual_override', 'true'); 
+        });
+
+        window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', event => {
+            if (!localStorage.getItem('theme_manual_override')) { 
+                 const newColorScheme = event.matches ? "dark" : "light";
+                 applyTheme(newColorScheme);
+                 localStorage.setItem('theme', newColorScheme);
+            }
+        });
+        
+        setTimeout(() => {
+            if (body.classList.contains('dark-mode')) {
+                 applyTheme('dark'); 
+            } else {
+                 applyTheme('light');
+            }
+        }, 1000); 
     </script>
 </body>
 

--- a/euro_simulator_app copy 14/app/templates/index.html
+++ b/euro_simulator_app copy 14/app/templates/index.html
@@ -8,25 +8,167 @@
     <link rel="shortcut icon" href="{{ url_for('static', filename='favicon.ico') }}">
     <style>
         :root {
-            --primary-color: #007bff;
-            --primary-hover: #0056b3;
-            --secondary-color: #6c757d;
-            --secondary-hover: #5a6268;
-            --light-bg: #f8f9fa;
-            --border-color: #dee2e6;
-            --text-color: #343a40;
-            --text-muted: #6c757d;
-            --card-bg: #ffffff;
-            --header-bg: #e9ecef;
-            --success-color: #28a745;
-            --danger-color: #dc3545;
-            --danger-hover: #c82333;
-            --stat-better: #28a745;
-            --stat-worse: #dc3545;
-            --stat-max: #17a2b8;
-            --stat-min: #ffc107;
-            --link-color: #007bff;
-            --link-hover: #0056b3;
+            /* Light Theme Variables */
+            --primary-color-light: #007bff;
+            --primary-hover-light: #0056b3;
+            --secondary-color-light: #6c757d;
+            --secondary-hover-light: #5a6268;
+            --light-bg-light: #f8f9fa; /* Used for forms, odd table rows */
+            --body-bg-light: #f4f4f4; /* Main page background */
+            --border-color-light: #dee2e6;
+            --text-color-light: #343a40;
+            --text-muted-light: #6c757d;
+            --card-bg-light: #ffffff;
+            --header-bg-light: #e9ecef;
+            --success-color-light: #28a745;
+            --danger-color-light: #dc3545;
+            --danger-hover-light: #c82333;
+            --stat-better-light: #28a745;
+            --stat-worse-light: #dc3545;
+            --stat-max-light: #17a2b8;
+            --stat-min-light: #ffc107;
+            --link-color-light: #007bff;
+            --link-hover-light: #0056b3;
+            --nav-bar-bg-light: #ffffff;
+            --select-arrow-color-light: '%236c757d'; /* #6c757d */
+            --table-hover-bg-light: #f1f1f1;
+            --details-border-light: #aaa;
+            --details-content-border-light: #eee;
+            --carousel-bg-light: #fdfdfd;
+            --carousel-header-text-light: #555;
+            --carousel-slide-text-light: #333;
+            --carousel-nav-disabled-bg-light: #ccc;
+            --group-overview-item-bg-light: #fff;
+            --group-overview-item-border-light: #e0e0e0;
+            --group-teams-table-header-text-light: #444;
+            --group-teams-table-row-border-light: #f0f0f0;
+            --th-sortable-hover-bg-light: #dde2e6;
+            --th-sortable-arrow-color-light: #333;
+            --qualifier-bg-light: #d4edda;
+            --checkbox-hover-bg-light: #e9ecef;
+            --checkbox-hover-border-light: #adb5bd;
+
+
+            /* Dark Theme Variables */
+            --primary-color-dark: #0d6efd;
+            --primary-hover-dark: #3385fd;
+            --secondary-color-dark: #5c636a;
+            --secondary-hover-dark: #494f54;
+            --light-bg-dark: #22272e; /* Used for forms, odd table rows */
+            --body-bg-dark: #1c2128;  /* Main page background */
+            --border-color-dark: #444c56;
+            --text-color-dark: #adbac7;
+            --text-muted-dark: #768390;
+            --card-bg-dark: #2d333b;
+            --header-bg-dark: #373e47;
+            --success-color-dark: #34c356; /* Brighter green */
+            --danger-color-dark: #f85149;  /* Brighter red */
+            --danger-hover-dark: #fa3d35;
+            --stat-better-dark: #34c356;
+            --stat-worse-dark: #f85149;
+            --stat-max-dark: #2cbce0; /* Brighter info blue */
+            --stat-min-dark: #ffca2c; /* Brighter warning yellow */
+            --link-color-dark: #2c8cff;
+            --link-hover-dark: #57a3ff;
+            --nav-bar-bg-dark: #2d333b;
+            --select-arrow-color-dark: '%23adbac7'; /* #adbac7 */
+            --table-hover-bg-dark: #373e47;
+            --details-border-dark: #555c66;
+            --details-content-border-dark: #444c56;
+            --carousel-bg-dark: #282e36;
+            --carousel-header-text-dark: #aab5c1;
+            --carousel-slide-text-dark: #adbac7;
+            --carousel-nav-disabled-bg-dark: #444c56;
+            --group-overview-item-bg-dark: #2d333b;
+            --group-overview-item-border-dark: #444c56;
+            --group-teams-table-header-text-dark: #adbac7;
+            --group-teams-table-row-border-dark: #373e47;
+            --th-sortable-hover-bg-dark: #404853;
+            --th-sortable-arrow-color-dark: #adbac7;
+            --qualifier-bg-dark: #2a5a3a !important; /* Darker green, needs !important due to specificity */
+            --checkbox-hover-bg-dark: #373e47;
+            --checkbox-hover-border-dark: #5a6268;
+
+            /* Default to Light Theme */
+            --primary-color: var(--primary-color-light);
+            --primary-hover: var(--primary-hover-light);
+            --secondary-color: var(--secondary-color-light);
+            --secondary-hover: var(--secondary-hover-light);
+            --light-bg: var(--light-bg-light);
+            --body-bg: var(--body-bg-light);
+            --border-color: var(--border-color-light);
+            --text-color: var(--text-color-light);
+            --text-muted: var(--text-muted-light);
+            --card-bg: var(--card-bg-light);
+            --header-bg: var(--header-bg-light);
+            --success-color: var(--success-color-light);
+            --danger-color: var(--danger-color-light);
+            --danger-hover: var(--danger-hover-light);
+            --stat-better: var(--stat-better-light);
+            --stat-worse: var(--stat-worse-light);
+            --stat-max: var(--stat-max-light);
+            --stat-min: var(--stat-min-light);
+            --link-color: var(--link-color-light);
+            --link-hover: var(--link-hover-light);
+            --nav-bar-bg: var(--nav-bar-bg-light);
+            --select-arrow-color: var(--select-arrow-color-light);
+            --table-hover-bg: var(--table-hover-bg-light);
+            --details-border: var(--details-border-light);
+            --details-content-border: var(--details-content-border-light);
+            --carousel-bg: var(--carousel-bg-light);
+            --carousel-header-text: var(--carousel-header-text-light);
+            --carousel-slide-text: var(--carousel-slide-text-light);
+            --carousel-nav-disabled-bg: var(--carousel-nav-disabled-bg-light);
+            --group-overview-item-bg: var(--group-overview-item-bg-light);
+            --group-overview-item-border: var(--group-overview-item-border-light);
+            --group-teams-table-header-text: var(--group-teams-table-header-text-light);
+            --group-teams-table-row-border: var(--group-teams-table-row-border-light);
+            --th-sortable-hover-bg: var(--th-sortable-hover-bg-light);
+            --th-sortable-arrow-color: var(--th-sortable-arrow-color-light);
+            --qualifier-bg: var(--qualifier-bg-light);
+            --checkbox-hover-bg: var(--checkbox-hover-bg-light);
+            --checkbox-hover-border: var(--checkbox-hover-border-light);
+        }
+
+        body.dark-mode {
+            --primary-color: var(--primary-color-dark);
+            --primary-hover: var(--primary-hover-dark);
+            --secondary-color: var(--secondary-color-dark);
+            --secondary-hover: var(--secondary-hover-dark);
+            --light-bg: var(--light-bg-dark);
+            --body-bg: var(--body-bg-dark);
+            --border-color: var(--border-color-dark);
+            --text-color: var(--text-color-dark);
+            --text-muted: var(--text-muted-dark);
+            --card-bg: var(--card-bg-dark);
+            --header-bg: var(--header-bg-dark);
+            --success-color: var(--success-color-dark);
+            --danger-color: var(--danger-color-dark);
+            --danger-hover: var(--danger-hover-dark);
+            --stat-better: var(--stat-better-dark);
+            --stat-worse: var(--stat-worse-dark);
+            --stat-max: var(--stat-max-dark);
+            --stat-min: var(--stat-min-dark);
+            --link-color: var(--link-color-dark);
+            --link-hover: var(--link-hover-dark);
+            --nav-bar-bg: var(--nav-bar-bg-dark);
+            --select-arrow-color: var(--select-arrow-color-dark);
+            --table-hover-bg: var(--table-hover-bg-dark);
+            --details-border: var(--details-border-dark);
+            --details-content-border: var(--details-content-border-dark);
+            --carousel-bg: var(--carousel-bg-dark);
+            --carousel-header-text: var(--carousel-header-text-dark);
+            --carousel-slide-text: var(--carousel-slide-text-dark);
+            --carousel-nav-disabled-bg: var(--carousel-nav-disabled-bg-dark);
+            --group-overview-item-bg: var(--group-overview-item-bg-dark);
+            --group-overview-item-border: var(--group-overview-item-border-dark);
+            --group-teams-table-header-text: var(--group-teams-table-header-text-dark);
+            --group-teams-table-row-border: var(--group-teams-table-row-border-dark);
+            --th-sortable-hover-bg: var(--th-sortable-hover-bg-dark);
+            --th-sortable-arrow-color: var(--th-sortable-arrow-color-dark);
+            --qualifier-bg: var(--qualifier-bg-dark);
+            --checkbox-hover-bg: var(--checkbox-hover-bg-dark);
+            --checkbox-hover-border: var(--checkbox-hover-border-dark);
         }
 
         body {
@@ -34,7 +176,7 @@
             margin: 0;
             padding: 20px;
             line-height: 1.6;
-            background-color: #f4f4f4;
+            background-color: var(--body-bg); /* Updated */
             color: var(--text-color);
             position: relative;
         }
@@ -100,7 +242,7 @@
             top: 0;
             left: 0;
             right: 0;
-            background-color: white;
+            background-color: var(--nav-bar-bg); /* Updated */
             box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
             z-index: 1000;
             padding: 10px 25px;
@@ -113,7 +255,23 @@
             font-weight: 600;
             font-size: 1.2em;
             color: var(--text-color);
+            margin-right: auto; /* Pushes toggle button to the right if it's next to title */
         }
+
+        #darkModeToggle {
+            background-color: var(--secondary-color);
+            color: white;
+            border: none;
+            padding: 8px 12px;
+            border-radius: 6px;
+            cursor: pointer;
+            font-size: 0.9em;
+            margin-left: 15px; /* Space from nav links or title */
+        }
+        body.dark-mode #darkModeToggle {
+            background-color: var(--primary-color); /* Or a specific toggle active color */
+        }
+
 
         .nav-links a {
             margin-left: 18px;
@@ -264,15 +422,23 @@
 
         select {
             appearance: none;
-            background-image: url('data:image/svg+xml;charset=US-ASCII,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22292.4%22%20height%3D%22292.4%22%3E%3Cpath%20fill%3D%22%236c757d%22%20d%3D%22M287%2069.4a17.6%2017.6%200%200%200-13-5.4H18.4c-5%200-9.3%201.8-12.9%205.4A17.6%2017.6%200%200%200%200%2082.2c0%205%201.8%209.3%205.4%2012.9l128%20127.9c3.6%203.6%207.8%205.4%2012.8%205.4s9.2-1.8%2012.8-5.4L287%2095c3.6-3.6%205.4-7.8%205.4-12.8%200-5-1.8-9.2-5.4-12.8z%22%2F%3E%3C%2Fsvg%3E');
+            /* The fill color in the SVG URL needs to be dynamic. We use a CSS variable. */
+            background-image: url('data:image/svg+xml;charset=US-ASCII,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22292.4%22%20height%3D%22292.4%22%3E%3Cpath%20fill%3D%22' + var(--select-arrow-color) + '%22%20d%3D%22M287%2069.4a17.6%2017.6%200%200%200-13-5.4H18.4c-5%200-9.3%201.8-12.9%205.4A17.6%2017.6%200%200%200%200%2082.2c0%205%201.8%209.3%205.4%2012.9l128%20127.9c3.6%203.6%207.8%205.4%2012.8%205.4s9.2-1.8%2012.8-5.4L287%2095c3.6-3.6%205.4-7.8%205.4-12.8%200-5-1.8-9.2-5.4-12.8z%22%2F%3E%3C%2Fsvg%3E');
             background-repeat: no-repeat;
             background-position: right 12px center;
             background-size: 10px 10px;
             padding-right: 35px;
         }
+        body:not(.dark-mode) select {
+             background-image: url('data:image/svg+xml;charset=US-ASCII,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22292.4%22%20height%3D%22292.4%22%3E%3Cpath%20fill%3D%22%236c757d%22%20d%3D%22M287%2069.4a17.6%2017.6%200%200%200-13-5.4H18.4c-5%200-9.3%201.8-12.9%205.4A17.6%2017.6%200%200%200%200%2082.2c0%205%201.8%209.3%205.4%2012.9l128%20127.9c3.6%203.6%207.8%205.4%2012.8%205.4s9.2-1.8%2012.8-5.4L287%2095c3.6-3.6%205.4-7.8%205.4-12.8%200-5-1.8-9.2-5.4-12.8z%22%2F%3E%3C%2Fsvg%3E');
+        }
+        body.dark-mode select {
+            background-image: url('data:image/svg+xml;charset=US-ASCII,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22292.4%22%20height%3D%22292.4%22%3E%3Cpath%20fill%3D%22%23adbac7%22%20d%3D%22M287%2069.4a17.6%2017.6%200%200%200-13-5.4H18.4c-5%200-9.3%201.8-12.9%205.4A17.6%2017.6%200%200%200%200%2082.2c0%205%201.8%209.3%205.4%2012.9l128%20127.9c3.6%203.6%207.8%205.4%2012.8%205.4s9.2-1.8%2012.8-5.4L287%2095c3.6-3.6%205.4-7.8%205.4-12.8%200-5-1.8-9.2-5.4-12.8z%22%2F%3E%3C%2Fsvg%3E');
+        }
+
 
         select:disabled {
-            background-color: #e9ecef;
+            background-color: var(--header-bg); /* Use variable */
             cursor: not-allowed;
             opacity: 0.7;
         }
@@ -325,8 +491,8 @@
 
         .checkbox-group input[type="checkbox"]:not(:checked)+label:hover,
         .radio-group input[type="radio"]:not(:checked)+label.radio-label:hover {
-            background-color: #e9ecef;
-            border-color: #adb5bd;
+            background-color: var(--checkbox-hover-bg); /* Use variable */
+            border-color: var(--checkbox-hover-border); /* Use variable */
             color: var(--text-color);
         }
 
@@ -374,7 +540,7 @@
         }
 
         tbody tr:hover {
-            background-color: #f1f1f1;
+            background-color: var(--table-hover-bg); /* Updated */
         }
 
         td.number,
@@ -393,7 +559,7 @@
         }
 
         th.sortable:hover {
-            background-color: #dde2e6;
+            background-color: var(--th-sortable-hover-bg); /* Updated */
         }
 
         th.sortable::after {
@@ -407,12 +573,12 @@
         }
 
         th.sortable.sort-asc::after {
-            border-bottom-color: #333;
+            border-bottom-color: var(--th-sortable-arrow-color); /* Updated */
             opacity: 1;
         }
 
         th.sortable.sort-desc::after {
-            border-top-color: #333;
+            border-top-color: var(--th-sortable-arrow-color); /* Updated */
             opacity: 1;
         }
 
@@ -464,8 +630,12 @@
         }
 
         tr.qualifier {
-            background-color: #d4edda !important;
+            background-color: var(--qualifier-bg) !important; /* Updated */
         }
+        body.dark-mode tr.qualifier td { /* Ensure text is readable on dark qualifier bg */
+            color: #e1e8ef; /* A light text color */
+        }
+
 
         .player-card {
             background-color: var(--card-bg);
@@ -494,7 +664,7 @@
         .player-card h2 {
             margin-top: 0;
             margin-bottom: 15px;
-            border-bottom: 1px solid #eee;
+            border-bottom: 1px solid var(--border-color); /* Updated */
             padding-bottom: 10px;
             font-size: 1.3em;
             font-weight: 600;
@@ -563,9 +733,9 @@
         .details-wrapper {
             margin-top: 30px;
             margin-bottom: 20px;
-            border: 1px solid #aaa;
+            border: 1px solid var(--details-border); /* Updated */
             border-radius: 5px;
-            background-color: #fff;
+            background-color: var(--card-bg); /* Updated */
             box-shadow: 0 3px 5px rgba(0, 0, 0, 0.07);
         }
 
@@ -575,7 +745,7 @@
             font-size: 1.1em;
             padding: 10px 15px;
             background-color: var(--header-bg);
-            border-bottom: 1px solid #aaa;
+            border-bottom: 1px solid var(--details-border); /* Updated */
             border-top-left-radius: 5px;
             border-top-right-radius: 5px;
             list-style: none;
@@ -605,13 +775,13 @@
 
         details .details-content {
             padding: 20px;
-            border-top: 1px solid #eee;
+            border-top: 1px solid var(--details-content-border); /* Updated */
         }
 
         details .details-content h3 {
             margin-top: 1.5em;
             margin-bottom: 0.8em;
-            border-bottom: 1px dotted #ccc;
+            border-bottom: 1px dotted var(--border-color); /* Updated */
             padding-bottom: 4px;
             font-size: 1.1em;
         }
@@ -624,7 +794,7 @@
             border: 1px solid var(--border-color);
             padding: 15px;
             margin-bottom: 25px;
-            background-color: #fdfdfd;
+            background-color: var(--carousel-bg); /* Updated */
             border-radius: 5px;
             box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
         }
@@ -633,12 +803,12 @@
             text-align: center;
             margin-bottom: 10px;
             padding-bottom: 5px;
-            border-bottom: 1px solid #eee;
+            border-bottom: 1px solid var(--border-color); /* Updated */
         }
 
         .carousel-header h4 {
             margin: 0;
-            color: #555;
+            color: var(--carousel-header-text); /* Updated */
             font-size: 1.1em;
             border-bottom: none;
         }
@@ -657,14 +827,14 @@
             margin-top: 0;
             margin-bottom: 10px;
             font-size: 1.15em;
-            color: #333;
+            color: var(--carousel-slide-text); /* Updated */
         }
 
         .carousel-nav {
             text-align: center;
             margin-top: 15px;
             padding-top: 10px;
-            border-top: 1px solid #eee;
+            border-top: 1px solid var(--border-color); /* Updated */
         }
 
         .carousel-nav button {
@@ -678,13 +848,17 @@
             font-size: 0.95em;
             transition: background-color 0.2s ease;
         }
+        body.dark-mode .carousel-nav button { /* Ensure button text is white on dark primary */
+             color: #fff;
+        }
+
 
         .carousel-nav button:hover {
             background-color: var(--primary-hover);
         }
 
         .carousel-nav button:disabled {
-            background-color: #ccc;
+            background-color: var(--carousel-nav-disabled-bg); /* Updated */
             cursor: not-allowed;
             opacity: 0.7;
         }
@@ -701,10 +875,10 @@
         }
 
         .group-overview-item {
-            border: 1px solid #e0e0e0;
+            border: 1px solid var(--group-overview-item-border); /* Updated */
             padding: 10px 15px;
             border-radius: 5px;
-            background-color: #fff;
+            background-color: var(--group-overview-item-bg); /* Updated */
             box-shadow: 0 1px 3px rgba(0, 0, 0, 0.04);
         }
 
@@ -713,9 +887,9 @@
             margin-bottom: 10px;
             text-align: center;
             font-size: 1.1em;
-            border-bottom: 1px solid #eee;
+            border-bottom: 1px solid var(--border-color); /* Updated */
             padding-bottom: 5px;
-            color: #333;
+            color: var(--text-color); /* Updated */
         }
 
         .group-teams-table {
@@ -731,15 +905,15 @@
             font-weight: 600;
             text-align: left;
             padding: 6px 8px;
-            color: #444;
+            color: var(--group-teams-table-header-text); /* Updated */
             border: none;
-            border-bottom: 1px solid #eee;
+            border-bottom: 1px solid var(--border-color); /* Updated */
         }
 
         .group-teams-table td {
             padding: 6px 8px;
             border: none;
-            border-bottom: 1px solid #f0f0f0;
+            border-bottom: 1px solid var(--group-teams-table-row-border); /* Updated */
             text-align: left;
         }
 
@@ -818,7 +992,7 @@
         }
 
         .team-grid-fixed li {
-            background-color: #fff;
+            background-color: var(--card-bg); /* Updated */
             border: 1px solid var(--border-color);
             border-radius: 6px;
             padding: 10px 15px;
@@ -973,7 +1147,14 @@
 </head>
 
 <body>
-
+    <div class="nav-bar">
+        <span class="nav-title">{{ title }} - Euro Simulátor</span>
+        <!-- Links will be added here by existing code if any, or can be added manually -->
+        <!-- <div class="nav-links"> -->
+        <!-- <a href="/">Home</a> -->
+        <!-- </div> -->
+        <button id="darkModeToggle" aria-label="Toggle dark mode">🌙</button>
+    </div>
 
     <div class="container">
 
@@ -1012,6 +1193,58 @@
         function showUnavailableAlert() {
             alert("Tato funkce není dostupná ve verzi nasazené na Heroku. Funguje pouze při lokálním spuštění aplikace.");
         }
+
+        const toggleButton = document.getElementById('darkModeToggle');
+        const body = document.body;
+
+        // Function to apply the saved theme and update button text/icon
+        function applyTheme(theme) {
+            if (theme === 'dark') {
+                body.classList.add('dark-mode');
+                toggleButton.textContent = '☀️'; // Sun icon for light mode
+                toggleButton.setAttribute('aria-label', 'Switch to Light Mode');
+            } else {
+                body.classList.remove('dark-mode');
+                toggleButton.textContent = '🌙'; // Moon icon for dark mode
+                toggleButton.setAttribute('aria-label', 'Switch to Dark Mode');
+            }
+        }
+
+        // Load saved theme from localStorage
+        let savedTheme = localStorage.getItem('theme');
+
+        // Check for system preference if no theme is saved
+        if (!savedTheme) {
+            if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+                savedTheme = 'dark';
+            } else {
+                savedTheme = 'light'; // Default to light if no system preference or saved theme
+            }
+        }
+        
+        applyTheme(savedTheme); // Apply the determined theme
+
+        toggleButton.addEventListener('click', () => {
+            if (body.classList.contains('dark-mode')) {
+                applyTheme('light');
+                localStorage.setItem('theme', 'light');
+            } else {
+                applyTheme('dark');
+                localStorage.setItem('theme', 'dark');
+            }
+        });
+
+        // Optional: Listen for changes in system preference and update if no user override
+        window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', event => {
+            // Only update if the user hasn't manually set a theme
+            // This logic can be enhanced if we want to allow "auto" mode vs "manual"
+            if (!localStorage.getItem('theme_manual_override')) {
+                 const newColorScheme = event.matches ? "dark" : "light";
+                 applyTheme(newColorScheme);
+                 localStorage.setItem('theme', newColorScheme);
+            }
+        });
+
     </script>
 </body>
 

--- a/euro_simulator_app copy 14/app/templates/player_comparison.html
+++ b/euro_simulator_app copy 14/app/templates/player_comparison.html
@@ -8,24 +8,200 @@
     <script src="https://cdn.plot.ly/plotly-2.30.0.min.js"></script>
     <style>
         :root {
-            --primary-color: #007bff;
-            --primary-hover: #0056b3;
-            --secondary-color: #6c757d;
-            --secondary-hover: #5a6268;
-            --light-bg: #f8f9fa;
-            --border-color: #dee2e6;
-            --text-color: #343a40;
-            --text-muted: #6c757d;
-            --card-bg: #ffffff;
-            --header-bg: #e9ecef;
-            --success-color: #28a745;
-            --danger-color: #dc3545;
-            --stat-better: #28a745;
-            --stat-worse: #dc3545;
-            --stat-max: #17a2b8;
-            --stat-min: #ffc107;
-            --link-color: #007bff;
-            --link-hover: #0056b3;
+            /* Light Theme Variables */
+            --primary-color-light: #007bff;
+            --primary-hover-light: #0056b3;
+            --secondary-color-light: #6c757d;
+            --secondary-hover-light: #5a6268;
+            --light-bg-light: #f8f9fa; 
+            --body-bg-light: #f4f4f4; 
+            --border-color-light: #dee2e6;
+            --text-color-light: #343a40;
+            --text-muted-light: #6c757d;
+            --card-bg-light: #ffffff;
+            --header-bg-light: #e9ecef;
+            --success-color-light: #28a745;
+            --danger-color-light: #dc3545;
+            --danger-hover-light: #c82333;
+            --stat-better-light: #28a745;
+            --stat-worse-light: #dc3545;
+            --stat-max-light: #17a2b8; 
+            --stat-min-light: #ffc107; 
+            --link-color-light: #007bff;
+            --link-hover-light: #0056b3;
+            --nav-bar-bg-light: #ffffff;
+            --select-arrow-color-light: '%236c757d'; 
+            --table-hover-bg-light: #f1f1f1;
+            --details-border-light: #aaa;
+            --details-content-border-light: #eee;
+            --carousel-bg-light: #fdfdfd;
+            --carousel-header-text-light: #555;
+            --carousel-slide-text-light: #333;
+            --carousel-nav-disabled-bg-light: #ccc;
+            --group-overview-item-bg-light: #fff;
+            --group-overview-item-border-light: #e0e0e0;
+            --group-teams-table-header-text-light: #444;
+            --group-teams-table-row-border-light: #f0f0f0;
+            --th-sortable-hover-bg-light: #dde2e6;
+            --th-sortable-arrow-color-light: #333;
+            --qualifier-bg-light: #d4edda;
+            --checkbox-hover-bg-light: #e9ecef;
+            --checkbox-hover-border-light: #adb5bd;
+            --button-disabled-bg-light: #ccc; 
+            --button-disabled-border-light: #bbb;
+            --button-disabled-text-light: #888;
+            --category-label-indeterminate-bg-light: #daf0FF;
+            --attribute-group-border-light: #ddd;
+            --box-shadow-light: rgba(0, 0, 0, 0.05);
+            --scope-toggle-hover-bg-light: #e9ecef;
+            --scope-toggle-hover-border-light: #adb5bd;
+
+
+            /* Dark Theme Variables */
+            --primary-color-dark: #0d6efd;
+            --primary-hover-dark: #3385fd;
+            --secondary-color-dark: #5c636a;
+            --secondary-hover-dark: #494f54;
+            --light-bg-dark: #22272e; 
+            --body-bg-dark: #1c2128;  
+            --border-color-dark: #444c56;
+            --text-color-dark: #adbac7;
+            --text-muted-dark: #768390;
+            --card-bg-dark: #2d333b;
+            --header-bg-dark: #373e47;
+            --success-color-dark: #34c356; 
+            --danger-color-dark: #f85149;  
+            --danger-hover-dark: #fa3d35;
+            --stat-better-dark: #34c356;
+            --stat-worse-dark: #f85149;
+            --stat-max-dark: #2cbce0; 
+            --stat-min-dark: #ffca2c; 
+            --link-color-dark: #2c8cff;
+            --link-hover-dark: #57a3ff;
+            --nav-bar-bg-dark: #2d333b;
+            --select-arrow-color-dark: '%23adbac7'; 
+            --table-hover-bg-dark: #373e47;
+            --details-border-dark: #555c66;
+            --details-content-border-dark: #444c56;
+            --carousel-bg-dark: #282e36;
+            --carousel-header-text-dark: #aab5c1;
+            --carousel-slide-text-dark: #adbac7;
+            --carousel-nav-disabled-bg-dark: #444c56;
+            --group-overview-item-bg-dark: #2d333b;
+            --group-overview-item-border-dark: #444c56;
+            --group-teams-table-header-text-dark: #adbac7;
+            --group-teams-table-row-border-dark: #373e47;
+            --th-sortable-hover-bg-dark: #404853;
+            --th-sortable-arrow-color-dark: #adbac7;
+            --qualifier-bg-dark: #2a5a3a !important; 
+            --checkbox-hover-bg-dark: #373e47;
+            --checkbox-hover-border-dark: #5a6268;
+            --button-disabled-bg-dark: #444c56;
+            --button-disabled-border-dark: #555c66;
+            --button-disabled-text-dark: #768390;
+            --category-label-indeterminate-bg-dark: #2a4a6e; 
+            --attribute-group-border-dark: var(--border-color-dark);
+            --box-shadow-dark: rgba(0, 0, 0, 0.25); 
+            --scope-toggle-hover-bg-dark: #373e47;
+            --scope-toggle-hover-border-dark: #5a6268;
+
+
+            /* Default to Light Theme */
+            --primary-color: var(--primary-color-light);
+            --primary-hover: var(--primary-hover-light);
+            --secondary-color: var(--secondary-color-light);
+            --secondary-hover: var(--secondary-hover-light);
+            --light-bg: var(--light-bg-light);
+            --body-bg: var(--body-bg-light);
+            --border-color: var(--border-color-light);
+            --text-color: var(--text-color-light);
+            --text-muted: var(--text-muted-light);
+            --card-bg: var(--card-bg-light);
+            --header-bg: var(--header-bg-light);
+            --success-color: var(--success-color-light);
+            --danger-color: var(--danger-color-light);
+            --danger-hover: var(--danger-hover-light);
+            --stat-better: var(--stat-better-light);
+            --stat-worse: var(--stat-worse-light);
+            --stat-max: var(--stat-max-light);
+            --stat-min: var(--stat-min-light);
+            --link-color: var(--link-color-light);
+            --link-hover: var(--link-hover-light);
+            --nav-bar-bg: var(--nav-bar-bg-light);
+            --select-arrow-color: var(--select-arrow-color-light);
+            --table-hover-bg: var(--table-hover-bg-light);
+            --details-border: var(--details-border-light);
+            --details-content-border: var(--details-content-border-light);
+            --carousel-bg: var(--carousel-bg-light);
+            --carousel-header-text: var(--carousel-header-text-light);
+            --carousel-slide-text: var(--carousel-slide-text-light);
+            --carousel-nav-disabled-bg: var(--carousel-nav-disabled-bg-light);
+            --group-overview-item-bg: var(--group-overview-item-bg-light);
+            --group-overview-item-border: var(--group-overview-item-border-light);
+            --group-teams-table-header-text: var(--group-teams-table-header-text-light);
+            --group-teams-table-row-border: var(--group-teams-table-row-border-light);
+            --th-sortable-hover-bg: var(--th-sortable-hover-bg-light);
+            --th-sortable-arrow-color: var(--th-sortable-arrow-color-light);
+            --qualifier-bg: var(--qualifier-bg-light);
+            --checkbox-hover-bg: var(--checkbox-hover-bg-light);
+            --checkbox-hover-border: var(--checkbox-hover-border-light);
+            --button-disabled-bg: var(--button-disabled-bg-light);
+            --button-disabled-border: var(--button-disabled-border-light);
+            --button-disabled-text: var(--button-disabled-text-light);
+            --category-label-indeterminate-bg: var(--category-label-indeterminate-bg-light);
+            --attribute-group-border: var(--attribute-group-border-light);
+            --box-shadow: var(--box-shadow-light);
+            --scope-toggle-hover-bg: var(--scope-toggle-hover-bg-light);
+            --scope-toggle-hover-border: var(--scope-toggle-hover-border-light);
+        }
+
+        body.dark-mode {
+            --primary-color: var(--primary-color-dark);
+            --primary-hover: var(--primary-hover-dark);
+            --secondary-color: var(--secondary-color-dark);
+            --secondary-hover: var(--secondary-hover-dark);
+            --light-bg: var(--light-bg-dark);
+            --body-bg: var(--body-bg-dark);
+            --border-color: var(--border-color-dark);
+            --text-color: var(--text-color-dark);
+            --text-muted: var(--text-muted-dark);
+            --card-bg: var(--card-bg-dark);
+            --header-bg: var(--header-bg-dark);
+            --success-color: var(--success-color-dark);
+            --danger-color: var(--danger-color-dark);
+            --danger-hover: var(--danger-hover-dark);
+            --stat-better: var(--stat-better-dark);
+            --stat-worse: var(--stat-worse-dark);
+            --stat-max: var(--stat-max-dark);
+            --stat-min: var(--stat-min-dark);
+            --link-color: var(--link-color-dark);
+            --link-hover: var(--link-hover-dark);
+            --nav-bar-bg: var(--nav-bar-bg-dark);
+            --select-arrow-color: var(--select-arrow-color-dark);
+            --table-hover-bg: var(--table-hover-bg-dark);
+            --details-border: var(--details-border-dark);
+            --details-content-border: var(--details-content-border-dark);
+            --carousel-bg: var(--carousel-bg-dark);
+            --carousel-header-text: var(--carousel-header-text-dark);
+            --carousel-slide-text: var(--carousel-slide-text-dark);
+            --carousel-nav-disabled-bg: var(--carousel-nav-disabled-bg-dark);
+            --group-overview-item-bg: var(--group-overview-item-bg-dark);
+            --group-overview-item-border: var(--group-overview-item-border-dark);
+            --group-teams-table-header-text: var(--group-teams-table-header-text-dark);
+            --group-teams-table-row-border: var(--group-teams-table-row-border-dark);
+            --th-sortable-hover-bg: var(--th-sortable-hover-bg-dark);
+            --th-sortable-arrow-color: var(--th-sortable-arrow-color-dark);
+            --qualifier-bg: var(--qualifier-bg-dark);
+            --checkbox-hover-bg: var(--checkbox-hover-bg-dark);
+            --checkbox-hover-border: var(--checkbox-hover-border-dark);
+            --button-disabled-bg: var(--button-disabled-bg-dark);
+            --button-disabled-border: var(--button-disabled-border-dark);
+            --button-disabled-text: var(--button-disabled-text-dark);
+            --category-label-indeterminate-bg: var(--category-label-indeterminate-bg-dark);
+            --attribute-group-border: var(--attribute-group-border-dark);
+            --box-shadow: var(--box-shadow-dark);
+            --scope-toggle-hover-bg: var(--scope-toggle-hover-bg-dark);
+            --scope-toggle-hover-border: var(--scope-toggle-hover-border-dark);
         }
 
         body {
@@ -33,7 +209,7 @@
             margin: 0;
             padding: 20px;
             line-height: 1.6;
-            background-color: #f4f4f4;
+            background-color: var(--body-bg);
             color: var(--text-color);
             position: relative;
             padding-top: 80px;
@@ -45,7 +221,7 @@
             padding: 25px;
             background-color: var(--card-bg);
             border-radius: 8px;
-            box-shadow: 0 4px 8px rgba(0, 0, 0, 0.05);
+            box-shadow: 0 4px 8px var(--box-shadow);
         }
 
         h1,
@@ -100,8 +276,8 @@
             top: 0;
             left: 0;
             right: 0;
-            background-color: white;
-            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+            background-color: var(--nav-bar-bg);
+            box-shadow: 0 2px 4px var(--box-shadow);
             z-index: 1000;
             padding: 10px 25px;
             display: flex;
@@ -116,6 +292,21 @@
             font-size: 1.2em;
             color: var(--text-color);
             flex-grow: 1;
+        }
+        
+        #darkModeToggle {
+            background-color: var(--secondary-color);
+            color: white;
+            border: none;
+            padding: 8px 12px;
+            border-radius: 6px;
+            cursor: pointer;
+            font-size: 0.9em;
+            margin-left: 15px; 
+            order: 3; 
+        }
+        body.dark-mode #darkModeToggle {
+            background-color: var(--primary-color);
         }
 
         .nav-toggle {
@@ -182,6 +373,9 @@
             border-color: var(--primary-color);
             color: white;
         }
+         body.dark-mode .btn-primary, body.dark-mode button.main-submit {
+            color: #fff;
+        }
 
         .btn-primary:hover,
         button.main-submit:hover {
@@ -194,9 +388,9 @@
         .btn-primary:disabled,
         button.main-submit:disabled,
         button:disabled {
-            background-color: var(--secondary-color);
-            border-color: var(--secondary-color);
-            color: #e9ecef;
+            background-color: var(--button-disabled-bg); /* Updated */
+            border-color: var(--button-disabled-border); /* Updated */
+            color: var(--button-disabled-text); /* Updated */
             cursor: not-allowed;
             opacity: 0.65;
         }
@@ -204,9 +398,9 @@
         .btn-primary:disabled:hover,
         button.main-submit:disabled:hover,
         button:disabled:hover {
-            background-color: var(--secondary-color);
-            border-color: var(--secondary-color);
-            color: #e9ecef;
+            background-color: var(--button-disabled-bg); /* Updated */
+            border-color: var(--button-disabled-border); /* Updated */
+            color: var(--button-disabled-text); /* Updated */
         }
 
         .btn-secondary,
@@ -215,6 +409,9 @@
             background-color: var(--secondary-color);
             border-color: var(--secondary-color);
             color: white;
+        }
+        body.dark-mode .btn-secondary, body.dark-mode a.reset-button, body.dark-mode a.back-button {
+            color: #fff;
         }
 
         .btn-secondary:hover,
@@ -235,7 +432,7 @@
             background-color: var(--light-bg);
             padding: 25px;
             border-radius: 8px;
-            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+            box-shadow: 0 2px 4px var(--box-shadow);
             margin-bottom: 30px;
             border: 1px solid var(--border-color);
         }
@@ -312,15 +509,21 @@
 
         select {
             appearance: none;
-            background-image: url('data:image/svg+xml;charset=US-ASCII,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22292.4%22%20height%3D%22292.4%22%3E%3Cpath%20fill%3D%22%236c757d%22%20d%3D%22M287%2069.4a17.6%2017.6%200%200%200-13-5.4H18.4c-5%200-9.3%201.8-12.9%205.4A17.6%2017.6%200%200%200%200%2082.2c0%205%201.8%209.3%205.4%2012.9l128%20127.9c3.6%203.6%207.8%205.4%2012.8%205.4s9.2-1.8%2012.8-5.4L287%2095c3.6-3.6%205.4-7.8%205.4-12.8%200-5-1.8-9.2-5.4-12.8z%22%2F%3E%3C%2Fsvg%3E');
+            background-image: url('data:image/svg+xml;charset=US-ASCII,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22292.4%22%20height%3D%22292.4%22%3E%3Cpath%20fill%3D%22' + var(--select-arrow-color) + '%22%20d%3D%22M287%2069.4a17.6%2017.6%200%200%200-13-5.4H18.4c-5%200-9.3%201.8-12.9%205.4A17.6%2017.6%200%200%200%200%2082.2c0%205%201.8%209.3%205.4%2012.9l128%20127.9c3.6%203.6%207.8%205.4%2012.8%205.4s9.2-1.8%2012.8-5.4L287%2095c3.6-3.6%205.4-7.8%205.4-12.8%200-5-1.8-9.2-5.4-12.8z%22%2F%3E%3C%2Fsvg%3E');
             background-repeat: no-repeat;
             background-position: right 12px center;
             background-size: 10px 10px;
             padding-right: 35px;
         }
+         body:not(.dark-mode) select {
+             background-image: url('data:image/svg+xml;charset=US-ASCII,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22292.4%22%20height%3D%22292.4%22%3E%3Cpath%20fill%3D%22%236c757d%22%20d%3D%22M287%2069.4a17.6%2017.6%200%200%200-13-5.4H18.4c-5%200-9.3%201.8-12.9%205.4A17.6%2017.6%200%200%200%200%2082.2c0%205%201.8%209.3%205.4%2012.9l128%20127.9c3.6%203.6%207.8%205.4%2012.8%205.4s9.2-1.8%2012.8-5.4L287%2095c3.6-3.6%205.4-7.8%205.4-12.8%200-5-1.8-9.2-5.4-12.8z%22%2F%3E%3C%2Fsvg%3E');
+        }
+        body.dark-mode select {
+            background-image: url('data:image/svg+xml;charset=US-ASCII,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22292.4%22%20height%3D%22292.4%22%3E%3Cpath%20fill%3D%22%23adbac7%22%20d%3D%22M287%2069.4a17.6%2017.6%200%200%200-13-5.4H18.4c-5%200-9.3%201.8-12.9%205.4A17.6%2017.6%200%200%200%200%2082.2c0%205%201.8%209.3%205.4%2012.9l128%20127.9c3.6%203.6%207.8%205.4%2012.8%205.4s9.2-1.8%2012.8-5.4L287%2095c3.6-3.6%205.4-7.8%205.4-12.8%200-5-1.8-9.2-5.4-12.8z%22%2F%3E%3C%2Fsvg%3E');
+        }
 
         select:disabled {
-            background-color: #e9ecef;
+            background-color: var(--header-bg); /* Updated */
             cursor: not-allowed;
             opacity: 0.7;
         }
@@ -370,11 +573,15 @@
             color: white;
             border-color: var(--primary-hover);
         }
+         body.dark-mode .checkbox-group input[type="checkbox"]:checked+label,
+         body.dark-mode .radio-group input[type="radio"]:checked+label.radio-label {
+            color: #fff;
+        }
 
         .checkbox-group input[type="checkbox"]:not(:checked)+label:hover,
         .radio-group input[type="radio"]:not(:checked)+label.radio-label:hover {
-            background-color: #e9ecef;
-            border-color: #adb5bd;
+            background-color: var(--checkbox-hover-bg); /* Updated */
+            border-color: var(--checkbox-hover-border); /* Updated */
             color: var(--text-color);
         }
 
@@ -389,7 +596,7 @@
             width: 100%;
             margin: 20px auto 30px auto;
             background-color: var(--card-bg);
-            box-shadow: 0 2px 5px rgba(0, 0, 0, 0.07);
+            box-shadow: 0 2px 5px var(--box-shadow); /* Updated */
             border-radius: 8px;
             overflow: hidden;
             border: 1px solid var(--border-color);
@@ -422,7 +629,7 @@
         }
 
         tbody tr:hover {
-            background-color: #f1f1f1;
+            background-color: var(--table-hover-bg); /* Updated */
         }
 
         td.number,
@@ -441,7 +648,7 @@
         }
 
         th.sortable:hover {
-            background-color: #dde2e6;
+            background-color: var(--th-sortable-hover-bg); /* Updated */
         }
 
         th.sortable::after {
@@ -455,12 +662,12 @@
         }
 
         th.sortable.sort-asc::after {
-            border-bottom-color: #333;
+            border-bottom-color: var(--th-sortable-arrow-color); /* Updated */
             opacity: 1;
         }
 
         th.sortable.sort-desc::after {
-            border-top-color: #333;
+            border-top-color: var(--th-sortable-arrow-color); /* Updated */
             opacity: 1;
         }
 
@@ -512,14 +719,17 @@
         }
 
         tr.qualifier {
-            background-color: #d4edda !important;
+            background-color: var(--qualifier-bg) !important; /* Updated */
+        }
+        body.dark-mode tr.qualifier td {
+            color: #e1e8ef; 
         }
 
         .player-card {
             background-color: var(--card-bg);
             padding: 25px;
             border-radius: 8px;
-            box-shadow: 0 4px 8px rgba(0, 0, 0, 0.05);
+            box-shadow: 0 4px 8px var(--box-shadow); /* Updated */
             margin-bottom: 20px;
             border: 1px solid var(--border-color);
         }
@@ -542,7 +752,7 @@
         .player-card h2 {
             margin-top: 0;
             margin-bottom: 15px;
-            border-bottom: 1px solid #eee;
+            border-bottom: 1px solid var(--border-color); /* Updated */
             padding-bottom: 10px;
             font-size: 1.3em;
             font-weight: 600;
@@ -580,7 +790,7 @@
             background-color: var(--card-bg);
             padding: 20px;
             border-radius: 8px;
-            box-shadow: 0 4px 8px rgba(0, 0, 0, 0.05);
+            box-shadow: 0 4px 8px var(--box-shadow); /* Updated */
             margin: 30px auto;
             max-width: 900px;
             border: 1px solid var(--border-color);
@@ -607,14 +817,17 @@
             border-left-color: var(--danger-color);
             color: var(--danger-color);
         }
+        body.dark-mode .error-message {
+            color: var(--danger-color-dark);
+        }
 
         .details-wrapper {
             margin-top: 30px;
             margin-bottom: 20px;
-            border: 1px solid #aaa;
+            border: 1px solid var(--details-border); /* Updated */
             border-radius: 5px;
-            background-color: #fff;
-            box-shadow: 0 3px 5px rgba(0, 0, 0, 0.07);
+            background-color: var(--card-bg); /* Updated */
+            box-shadow: 0 3px 5px var(--box-shadow); /* Updated */
         }
 
         details summary {
@@ -623,7 +836,7 @@
             font-size: 1.1em;
             padding: 10px 15px;
             background-color: var(--header-bg);
-            border-bottom: 1px solid #aaa;
+            border-bottom: 1px solid var(--details-border); /* Updated */
             border-top-left-radius: 5px;
             border-top-right-radius: 5px;
             list-style: none;
@@ -648,18 +861,21 @@
 
         details summary:focus {
             outline: none;
-            box-shadow: 0 0 0 2px rgba(0, 123, 255, 0.25);
+            box-shadow: 0 0 0 2px rgba(0, 123, 255, 0.25); /* Needs theming */
+        }
+        body.dark-mode details summary:focus {
+             box-shadow: 0 0 0 2px rgba(var(--primary-color-dark-rgb, 13, 110, 253), 0.35);
         }
 
         details .details-content {
             padding: 20px;
-            border-top: 1px solid #eee;
+            border-top: 1px solid var(--details-content-border); /* Updated */
         }
 
         details .details-content h3 {
             margin-top: 1.5em;
             margin-bottom: 0.8em;
-            border-bottom: 1px dotted #ccc;
+            border-bottom: 1px dotted var(--border-color); /* Updated */
             padding-bottom: 4px;
             font-size: 1.1em;
         }
@@ -672,21 +888,21 @@
             border: 1px solid var(--border-color);
             padding: 15px;
             margin-bottom: 25px;
-            background-color: #fdfdfd;
+            background-color: var(--carousel-bg); /* Updated */
             border-radius: 5px;
-            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+            box-shadow: 0 2px 4px var(--box-shadow); /* Updated */
         }
 
         .carousel-header {
             text-align: center;
             margin-bottom: 10px;
             padding-bottom: 5px;
-            border-bottom: 1px solid #eee;
+            border-bottom: 1px solid var(--border-color); /* Updated */
         }
 
         .carousel-header h4 {
             margin: 0;
-            color: #555;
+            color: var(--carousel-header-text); /* Updated */
             font-size: 1.1em;
             border-bottom: none;
         }
@@ -705,14 +921,14 @@
             margin-top: 0;
             margin-bottom: 10px;
             font-size: 1.15em;
-            color: #333;
+            color: var(--carousel-slide-text); /* Updated */
         }
 
         .carousel-nav {
             text-align: center;
             margin-top: 15px;
             padding-top: 10px;
-            border-top: 1px solid #eee;
+            border-top: 1px solid var(--border-color); /* Updated */
         }
 
         .carousel-nav button {
@@ -726,13 +942,16 @@
             font-size: 0.95em;
             transition: background-color 0.2s ease;
         }
+        body.dark-mode .carousel-nav button {
+             color: #fff;
+        }
 
         .carousel-nav button:hover {
             background-color: var(--primary-hover);
         }
 
         .carousel-nav button:disabled {
-            background-color: #ccc;
+            background-color: var(--carousel-nav-disabled-bg); /* Updated */
             cursor: not-allowed;
             opacity: 0.7;
         }
@@ -749,11 +968,11 @@
         }
 
         .group-overview-item {
-            border: 1px solid #e0e0e0;
+            border: 1px solid var(--group-overview-item-border); /* Updated */
             padding: 10px 15px;
             border-radius: 5px;
-            background-color: #fff;
-            box-shadow: 0 1px 3px rgba(0, 0, 0, 0.04);
+            background-color: var(--group-overview-item-bg); /* Updated */
+            box-shadow: 0 1px 3px var(--box-shadow); /* Updated */
         }
 
         .group-overview-item h4 {
@@ -761,9 +980,9 @@
             margin-bottom: 10px;
             text-align: center;
             font-size: 1.1em;
-            border-bottom: 1px solid #eee;
+            border-bottom: 1px solid var(--border-color); /* Updated */
             padding-bottom: 5px;
-            color: #333;
+            color: var(--text-color); /* Updated */
         }
 
         .group-teams-table {
@@ -779,15 +998,15 @@
             font-weight: 600;
             text-align: left;
             padding: 6px 8px;
-            color: #444;
+            color: var(--group-teams-table-header-text); /* Updated */
             border: none;
-            border-bottom: 1px solid #eee;
+            border-bottom: 1px solid var(--border-color); /* Updated */
         }
 
         .group-teams-table td {
             padding: 6px 8px;
             border: none;
-            border-bottom: 1px solid #f0f0f0;
+            border-bottom: 1px solid var(--group-teams-table-row-border); /* Updated */
             text-align: left;
         }
 
@@ -820,8 +1039,12 @@
 
         .sticky-top {
             position: sticky;
-            top: 0;
+            top: 0; 
             z-index: 100;
+            background-color: var(--header-bg); /* Ensure header is visible */
+        }
+        body.dark-mode .sticky-top {
+             background-color: var(--header-bg-dark);
         }
 
         hr {
@@ -880,9 +1103,9 @@
         }
 
         .position-category-checkbox:not(:checked)+label.category-label:hover,
-        label.category-label:hover {
-            background-color: #dde2e6 !important;
-            border-color: #adb5bd !important;
+        label.category-label:hover { /* General hover for category labels if not specific enough */
+            background-color: var(--checkbox-hover-bg) !important;
+            border-color: var(--checkbox-hover-border) !important;
         }
 
         label.category-label.category-label-checked {
@@ -890,11 +1113,17 @@
             color: white !important;
             border-color: var(--primary-hover) !important;
         }
+        body.dark-mode label.category-label.category-label-checked {
+            color: #fff !important;
+        }
 
         label.category-label.category-label-indeterminate {
-            background-color: #daf0FF !important;
-            color: var(--primary-hover) !important;
+            background-color: var(--category-label-indeterminate-bg) !important;
+            color: var(--primary-hover) !important; /* Needs review for dark mode */
             border-color: var(--primary-color) !important;
+        }
+        body.dark-mode label.category-label.category-label-indeterminate {
+             color: var(--primary-hover-dark) !important;
         }
 
         .position-specifics-container {
@@ -927,10 +1156,13 @@
             color: white;
             border-color: var(--primary-hover);
         }
+         body.dark-mode .position-specifics-container .checkbox-group input[type="checkbox"]:checked+label {
+            color: #fff;
+        }
 
         .position-specifics-container .checkbox-group input[type="checkbox"]:not(:checked)+label:hover {
-            background-color: #e9ecef;
-            border-color: #adb5bd;
+            background-color: var(--checkbox-hover-bg); /* Updated */
+            border-color: var(--checkbox-hover-border); /* Updated */
             color: var(--text-color);
         }
 
@@ -947,17 +1179,22 @@
 
         @media (max-width: 768px) {
             body {
-                padding-top: 60px;
+                /* padding-top: 60px; */ /* Adjusted by nav-bar height */
             }
 
             .nav-bar {
                 padding: 5px 15px;
-                flex-wrap: wrap;/
+                /* flex-wrap: wrap; Already set */
             }
-
+            
             .nav-toggle {
                 display: block;
                 flex-shrink: 0;
+                margin-left: 10px;
+                order: 2; /* After title */
+            }
+            #darkModeToggle {
+                order: 3; /* After nav-toggle */
                 margin-left: 10px;
             }
 
@@ -966,15 +1203,15 @@
                 flex-direction: column;
                 width: 100%;
                 align-items: flex-start;
-                background-color: white;
+                background-color: var(--nav-bar-bg); /* Updated */
                 padding-top: 10px;
                 padding-bottom: 10px;
-                box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+                box-shadow: 0 4px 6px var(--box-shadow); /* Updated */
                 position: absolute;
                 top: 100%;
                 left: 0;
                 right: 0;
-                order: 3;
+                order: 4; /* Below all other nav items */
             }
 
             .nav-links.active {
@@ -998,12 +1235,20 @@
             .nav-links a.active {
                 background-color: var(--light-bg);
                 color: var(--primary-hover);
-                border-bottom-color: var(--border-color);
+                border-bottom-color: var(--border-color); /* Or primary-hover */
+            }
+            body.dark-mode .nav-links a:hover, body.dark-mode .nav-links a.active {
+                 background-color: var(--light-bg-dark);
+                 color: var(--primary-hover-dark);
+                 border-bottom-color: var(--border-color-dark);
             }
 
             .nav-links a.active {
                 font-weight: 600;
                 border-bottom-color: var(--primary-hover);
+            }
+             body.dark-mode .nav-links a.active {
+                border-bottom-color: var(--primary-hover-dark);
             }
 
             .nav-title {
@@ -1011,10 +1256,10 @@
                 margin-right: auto;
             }
 
-            .nav-toggle {
+            /* .nav-toggle {
                 display: block;
                 margin-left: 10px;
-            }
+            } */
 
             .container {
                 padding: 15px;
@@ -1093,6 +1338,7 @@
             <a href="{{ url_for('correlation_analysis') }}"
                 class="{{ 'active' if active_page == 'correlation' }}">Korelační Analýza</a>
         </div>
+        <button id="darkModeToggle" aria-label="Toggle dark mode">🌙</button>
     </nav>
     <div class="container">
 
@@ -1608,6 +1854,100 @@
             return player.position || player.primary_position || 'N/A';
         }
 
+    </script>
+    <script>
+        const toggleButton = document.getElementById('darkModeToggle');
+        const body = document.body;
+
+        function applyTheme(theme) {
+            if (theme === 'dark') {
+                body.classList.add('dark-mode');
+                toggleButton.textContent = '☀️'; 
+                toggleButton.setAttribute('aria-label', 'Switch to Light Mode');
+                if (typeof Plotly !== 'undefined') {
+                    document.querySelectorAll('.chart-div, .chart, #radarChartContainer, #radarChart').forEach(chartElement => {
+                        if (chartElement.layout) { 
+                            Plotly.relayout(chartElement, {
+                                'plot_bgcolor': 'var(--card-bg-dark)',
+                                'paper_bgcolor': 'var(--card-bg-dark)',
+                                'font.color': 'var(--text-color-dark)',
+                                'xaxis.color': 'var(--text-muted-dark)',
+                                'yaxis.color': 'var(--text-muted-dark)',
+                                'xaxis.gridcolor': 'var(--border-color-dark)',
+                                'yaxis.gridcolor': 'var(--border-color-dark)',
+                                'legend.bgcolor': 'var(--card-bg-dark)',
+                                'legend.bordercolor': 'var(--border-color-dark)',
+                                'polar.bgcolor': 'var(--card-bg-dark)',
+                                'polar.angularaxis.gridcolor': 'var(--border-color-dark)',
+                                'polar.radialaxis.gridcolor': 'var(--border-color-dark)',
+                                'polar.angularaxis.linecolor': 'var(--border-color-dark)',
+                                'polar.radialaxis.linecolor': 'var(--border-color-dark)',
+                                'polar.angularaxis.tickcolor': 'var(--text-muted-dark)',
+                                'polar.radialaxis.tickcolor': 'var(--text-muted-dark)',
+                            });
+                        }
+                    });
+                }
+            } else {
+                body.classList.remove('dark-mode');
+                toggleButton.textContent = '🌙'; 
+                toggleButton.setAttribute('aria-label', 'Switch to Dark Mode');
+                if (typeof Plotly !== 'undefined') {
+                    document.querySelectorAll('.chart-div, .chart, #radarChartContainer, #radarChart').forEach(chartElement => {
+                        if (chartElement.layout) { 
+                            Plotly.relayout(chartElement, {
+                                'plot_bgcolor': 'var(--card-bg-light)',
+                                'paper_bgcolor': 'var(--card-bg-light)',
+                                'font.color': 'var(--text-color-light)',
+                                'xaxis.color': 'var(--text-muted-light)',
+                                'yaxis.color': 'var(--text-muted-light)',
+                                'xaxis.gridcolor': 'var(--border-color-light)',
+                                'yaxis.gridcolor': 'var(--border-color-light)',
+                                'legend.bgcolor': 'var(--card-bg-light)',
+                                'legend.bordercolor': 'var(--border-color-light)',
+                                'polar.bgcolor': 'var(--card-bg-light)',
+                                'polar.angularaxis.gridcolor': 'var(--border-color-light)',
+                                'polar.radialaxis.gridcolor': 'var(--border-color-light)',
+                                'polar.angularaxis.linecolor': 'var(--border-color-light)',
+                                'polar.radialaxis.linecolor': 'var(--border-color-light)',
+                                'polar.angularaxis.tickcolor': 'var(--text-muted-light)',
+                                'polar.radialaxis.tickcolor': 'var(--text-muted-light)',
+                            });
+                        }
+                    });
+                }
+            }
+        }
+
+        let savedTheme = localStorage.getItem('theme');
+        if (!savedTheme) {
+            savedTheme = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+        }
+        applyTheme(savedTheme);
+
+        toggleButton.addEventListener('click', () => {
+            const currentTheme = body.classList.contains('dark-mode') ? 'dark' : 'light';
+            const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
+            applyTheme(newTheme);
+            localStorage.setItem('theme', newTheme);
+            localStorage.setItem('theme_manual_override', 'true');
+        });
+
+        window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', event => {
+            if (!localStorage.getItem('theme_manual_override')) {
+                 const newColorScheme = event.matches ? "dark" : "light";
+                 applyTheme(newColorScheme);
+                 localStorage.setItem('theme', newColorScheme);
+            }
+        });
+        
+        setTimeout(() => {
+            if (body.classList.contains('dark-mode')) {
+                 applyTheme('dark'); 
+            } else {
+                 applyTheme('light');
+            }
+        }, 500); // Delay to catch charts rendered after initial page load
     </script>
 </body>
 

--- a/euro_simulator_app copy 14/app/templates/simulation_results.html
+++ b/euro_simulator_app copy 14/app/templates/simulation_results.html
@@ -9,24 +9,200 @@
     <script src="https://cdn.plot.ly/plotly-2.30.0.min.js"></script>
     <style>
         :root {
-            --primary-color: #007bff;
-            --primary-hover: #0056b3;
-            --secondary-color: #6c757d;
-            --secondary-hover: #5a6268;
-            --light-bg: #f8f9fa;
-            --border-color: #dee2e6;
-            --text-color: #343a40;
-            --text-muted: #6c757d;
-            --card-bg: #ffffff;
-            --header-bg: #e9ecef;
-            --success-color: #28a745;
-            --danger-color: #dc3545;
-            --stat-better: #28a745;
-            --stat-worse: #dc3545;
-            --stat-max: #17a2b8;
-            --stat-min: #ffc107;
-            --link-color: #007bff;
-            --link-hover: #0056b3;
+            /* Light Theme Variables */
+            --primary-color-light: #007bff;
+            --primary-hover-light: #0056b3;
+            --secondary-color-light: #6c757d;
+            --secondary-hover-light: #5a6268;
+            --light-bg-light: #f8f9fa; 
+            --body-bg-light: #f4f4f4; 
+            --border-color-light: #dee2e6;
+            --text-color-light: #343a40;
+            --text-muted-light: #6c757d;
+            --card-bg-light: #ffffff;
+            --header-bg-light: #e9ecef;
+            --success-color-light: #28a745;
+            --danger-color-light: #dc3545;
+            --danger-hover-light: #c82333;
+            --stat-better-light: #28a745;
+            --stat-worse-light: #dc3545;
+            --stat-max-light: #17a2b8; 
+            --stat-min-light: #ffc107; 
+            --link-color-light: #007bff;
+            --link-hover-light: #0056b3;
+            --nav-bar-bg-light: #ffffff;
+            --select-arrow-color-light: '%236c757d'; 
+            --table-hover-bg-light: #f1f1f1;
+            --details-border-light: #aaa;
+            --details-content-border-light: #eee;
+            --carousel-bg-light: #fdfdfd;
+            --carousel-header-text-light: #555;
+            --carousel-slide-text-light: #333;
+            --carousel-nav-disabled-bg-light: #ccc;
+            --group-overview-item-bg-light: #fff;
+            --group-overview-item-border-light: #e0e0e0;
+            --group-teams-table-header-text-light: #444;
+            --group-teams-table-row-border-light: #f0f0f0;
+            --th-sortable-hover-bg-light: #dde2e6;
+            --th-sortable-arrow-color-light: #333;
+            --qualifier-bg-light: #d4edda;
+            --checkbox-hover-bg-light: #e9ecef;
+            --checkbox-hover-border-light: #adb5bd;
+            --button-disabled-bg-light: #ccc; 
+            --button-disabled-border-light: #bbb;
+            --button-disabled-text-light: #888;
+            --category-label-indeterminate-bg-light: #daf0FF;
+            --attribute-group-border-light: #ddd;
+            --box-shadow-light: rgba(0, 0, 0, 0.05);
+            --scope-toggle-hover-bg-light: #e9ecef;
+            --scope-toggle-hover-border-light: #adb5bd;
+
+
+            /* Dark Theme Variables */
+            --primary-color-dark: #0d6efd;
+            --primary-hover-dark: #3385fd;
+            --secondary-color-dark: #5c636a;
+            --secondary-hover-dark: #494f54;
+            --light-bg-dark: #22272e; 
+            --body-bg-dark: #1c2128;  
+            --border-color-dark: #444c56;
+            --text-color-dark: #adbac7;
+            --text-muted-dark: #768390;
+            --card-bg-dark: #2d333b;
+            --header-bg-dark: #373e47;
+            --success-color-dark: #34c356; 
+            --danger-color-dark: #f85149;  
+            --danger-hover-dark: #fa3d35;
+            --stat-better-dark: #34c356;
+            --stat-worse-dark: #f85149;
+            --stat-max-dark: #2cbce0; 
+            --stat-min-dark: #ffca2c; 
+            --link-color-dark: #2c8cff;
+            --link-hover-dark: #57a3ff;
+            --nav-bar-bg-dark: #2d333b;
+            --select-arrow-color-dark: '%23adbac7'; 
+            --table-hover-bg-dark: #373e47;
+            --details-border-dark: #555c66;
+            --details-content-border-dark: #444c56;
+            --carousel-bg-dark: #282e36;
+            --carousel-header-text-dark: #aab5c1;
+            --carousel-slide-text-dark: #adbac7;
+            --carousel-nav-disabled-bg-dark: #444c56;
+            --group-overview-item-bg-dark: #2d333b;
+            --group-overview-item-border-dark: #444c56;
+            --group-teams-table-header-text-dark: #adbac7;
+            --group-teams-table-row-border-dark: #373e47;
+            --th-sortable-hover-bg-dark: #404853;
+            --th-sortable-arrow-color-dark: #adbac7;
+            --qualifier-bg-dark: #2a5a3a !important; 
+            --checkbox-hover-bg-dark: #373e47;
+            --checkbox-hover-border-dark: #5a6268;
+            --button-disabled-bg-dark: #444c56;
+            --button-disabled-border-dark: #555c66;
+            --button-disabled-text-dark: #768390;
+            --category-label-indeterminate-bg-dark: #2a4a6e; 
+            --attribute-group-border-dark: var(--border-color-dark);
+            --box-shadow-dark: rgba(0, 0, 0, 0.25); 
+            --scope-toggle-hover-bg-dark: #373e47;
+            --scope-toggle-hover-border-dark: #5a6268;
+
+
+            /* Default to Light Theme */
+            --primary-color: var(--primary-color-light);
+            --primary-hover: var(--primary-hover-light);
+            --secondary-color: var(--secondary-color-light);
+            --secondary-hover: var(--secondary-hover-light);
+            --light-bg: var(--light-bg-light);
+            --body-bg: var(--body-bg-light);
+            --border-color: var(--border-color-light);
+            --text-color: var(--text-color-light);
+            --text-muted: var(--text-muted-light);
+            --card-bg: var(--card-bg-light);
+            --header-bg: var(--header-bg-light);
+            --success-color: var(--success-color-light);
+            --danger-color: var(--danger-color-light);
+            --danger-hover: var(--danger-hover-light);
+            --stat-better: var(--stat-better-light);
+            --stat-worse: var(--stat-worse-light);
+            --stat-max: var(--stat-max-light);
+            --stat-min: var(--stat-min-light);
+            --link-color: var(--link-color-light);
+            --link-hover: var(--link-hover-light);
+            --nav-bar-bg: var(--nav-bar-bg-light);
+            --select-arrow-color: var(--select-arrow-color-light);
+            --table-hover-bg: var(--table-hover-bg-light);
+            --details-border: var(--details-border-light);
+            --details-content-border: var(--details-content-border-light);
+            --carousel-bg: var(--carousel-bg-light);
+            --carousel-header-text: var(--carousel-header-text-light);
+            --carousel-slide-text: var(--carousel-slide-text-light);
+            --carousel-nav-disabled-bg: var(--carousel-nav-disabled-bg-light);
+            --group-overview-item-bg: var(--group-overview-item-bg-light);
+            --group-overview-item-border: var(--group-overview-item-border-light);
+            --group-teams-table-header-text: var(--group-teams-table-header-text-light);
+            --group-teams-table-row-border: var(--group-teams-table-row-border-light);
+            --th-sortable-hover-bg: var(--th-sortable-hover-bg-light);
+            --th-sortable-arrow-color: var(--th-sortable-arrow-color-light);
+            --qualifier-bg: var(--qualifier-bg-light);
+            --checkbox-hover-bg: var(--checkbox-hover-bg-light);
+            --checkbox-hover-border: var(--checkbox-hover-border-light);
+            --button-disabled-bg: var(--button-disabled-bg-light);
+            --button-disabled-border: var(--button-disabled-border-light);
+            --button-disabled-text: var(--button-disabled-text-light);
+            --category-label-indeterminate-bg: var(--category-label-indeterminate-bg-light);
+            --attribute-group-border: var(--attribute-group-border-light);
+            --box-shadow: var(--box-shadow-light);
+            --scope-toggle-hover-bg: var(--scope-toggle-hover-bg-light);
+            --scope-toggle-hover-border: var(--scope-toggle-hover-border-light);
+        }
+
+        body.dark-mode {
+            --primary-color: var(--primary-color-dark);
+            --primary-hover: var(--primary-hover-dark);
+            --secondary-color: var(--secondary-color-dark);
+            --secondary-hover: var(--secondary-hover-dark);
+            --light-bg: var(--light-bg-dark);
+            --body-bg: var(--body-bg-dark);
+            --border-color: var(--border-color-dark);
+            --text-color: var(--text-color-dark);
+            --text-muted: var(--text-muted-dark);
+            --card-bg: var(--card-bg-dark);
+            --header-bg: var(--header-bg-dark);
+            --success-color: var(--success-color-dark);
+            --danger-color: var(--danger-color-dark);
+            --danger-hover: var(--danger-hover-dark);
+            --stat-better: var(--stat-better-dark);
+            --stat-worse: var(--stat-worse-dark);
+            --stat-max: var(--stat-max-dark);
+            --stat-min: var(--stat-min-dark);
+            --link-color: var(--link-color-dark);
+            --link-hover: var(--link-hover-dark);
+            --nav-bar-bg: var(--nav-bar-bg-dark);
+            --select-arrow-color: var(--select-arrow-color-dark);
+            --table-hover-bg: var(--table-hover-bg-dark);
+            --details-border: var(--details-border-dark);
+            --details-content-border: var(--details-content-border-dark);
+            --carousel-bg: var(--carousel-bg-dark);
+            --carousel-header-text: var(--carousel-header-text-dark);
+            --carousel-slide-text: var(--carousel-slide-text-dark);
+            --carousel-nav-disabled-bg: var(--carousel-nav-disabled-bg-dark);
+            --group-overview-item-bg: var(--group-overview-item-bg-dark);
+            --group-overview-item-border: var(--group-overview-item-border-dark);
+            --group-teams-table-header-text: var(--group-teams-table-header-text-dark);
+            --group-teams-table-row-border: var(--group-teams-table-row-border-dark);
+            --th-sortable-hover-bg: var(--th-sortable-hover-bg-dark);
+            --th-sortable-arrow-color: var(--th-sortable-arrow-color-dark);
+            --qualifier-bg: var(--qualifier-bg-dark);
+            --checkbox-hover-bg: var(--checkbox-hover-bg-dark);
+            --checkbox-hover-border: var(--checkbox-hover-border-dark);
+            --button-disabled-bg: var(--button-disabled-bg-dark);
+            --button-disabled-border: var(--button-disabled-border-dark);
+            --button-disabled-text: var(--button-disabled-text-dark);
+            --category-label-indeterminate-bg: var(--category-label-indeterminate-bg-dark);
+            --attribute-group-border: var(--attribute-group-border-dark);
+            --box-shadow: var(--box-shadow-dark);
+            --scope-toggle-hover-bg: var(--scope-toggle-hover-bg-dark);
+            --scope-toggle-hover-border: var(--scope-toggle-hover-border-dark);
         }
 
         body {
@@ -34,7 +210,7 @@
             margin: 0;
             padding: 20px;
             line-height: 1.6;
-            background-color: #f4f4f4;
+            background-color: var(--body-bg);
             color: var(--text-color);
             position: relative;
             padding-top: 80px;
@@ -46,7 +222,7 @@
             padding: 25px;
             background-color: var(--card-bg);
             border-radius: 8px;
-            box-shadow: 0 4px 8px rgba(0, 0, 0, 0.05);
+            box-shadow: 0 4px 8px var(--box-shadow);
         }
 
         h1,
@@ -101,8 +277,8 @@
             top: 0;
             left: 0;
             right: 0;
-            background-color: white;
-            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+            background-color: var(--nav-bar-bg);
+            box-shadow: 0 2px 4px var(--box-shadow);
             z-index: 1000;
             padding: 10px 25px;
             display: flex;
@@ -117,6 +293,21 @@
             font-size: 1.2em;
             color: var(--text-color);
             flex-grow: 1;
+        }
+        
+        #darkModeToggle {
+            background-color: var(--secondary-color);
+            color: white;
+            border: none;
+            padding: 8px 12px;
+            border-radius: 6px;
+            cursor: pointer;
+            font-size: 0.9em;
+            margin-left: 15px; 
+            order: 3; 
+        }
+        body.dark-mode #darkModeToggle {
+            background-color: var(--primary-color);
         }
 
         .nav-toggle {
@@ -183,6 +374,9 @@
             border-color: var(--primary-color);
             color: white;
         }
+         body.dark-mode .btn-primary, body.dark-mode button.main-submit {
+            color: #fff;
+        }
 
         .btn-primary:hover,
         button.main-submit:hover {
@@ -199,6 +393,10 @@
             border-color: var(--secondary-color);
             color: white;
         }
+        body.dark-mode .btn-secondary, body.dark-mode a.reset-button, body.dark-mode a.back-button {
+            color: #fff;
+        }
+
 
         .btn-secondary:hover,
         a.reset-button:hover,
@@ -218,7 +416,7 @@
             background-color: var(--light-bg);
             padding: 25px;
             border-radius: 8px;
-            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+            box-shadow: 0 2px 4px var(--box-shadow);
             margin-bottom: 30px;
             border: 1px solid var(--border-color);
         }
@@ -277,15 +475,21 @@
 
         select {
             appearance: none;
-            background-image: url('data:image/svg+xml;charset=US-ASCII,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22292.4%22%20height%3D%22292.4%22%3E%3Cpath%20fill%3D%22%236c757d%22%20d%3D%22M287%2069.4a17.6%2017.6%200%200%200-13-5.4H18.4c-5%200-9.3%201.8-12.9%205.4A17.6%2017.6%200%200%200%200%2082.2c0%205%201.8%209.3%205.4%2012.9l128%20127.9c3.6%203.6%207.8%205.4%2012.8%205.4s9.2-1.8%2012.8-5.4L287%2095c3.6-3.6%205.4-7.8%205.4-12.8%200-5-1.8-9.2-5.4-12.8z%22%2F%3E%3C%2Fsvg%3E');
+            background-image: url('data:image/svg+xml;charset=US-ASCII,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22292.4%22%20height%3D%22292.4%22%3E%3Cpath%20fill%3D%22' + var(--select-arrow-color) + '%22%20d%3D%22M287%2069.4a17.6%2017.6%200%200%200-13-5.4H18.4c-5%200-9.3%201.8-12.9%205.4A17.6%2017.6%200%200%200%200%2082.2c0%205%201.8%209.3%205.4%2012.9l128%20127.9c3.6%203.6%207.8%205.4%2012.8%205.4s9.2-1.8%2012.8-5.4L287%2095c3.6-3.6%205.4-7.8%205.4-12.8%200-5-1.8-9.2-5.4-12.8z%22%2F%3E%3C%2Fsvg%3E');
             background-repeat: no-repeat;
             background-position: right 12px center;
             background-size: 10px 10px;
             padding-right: 35px;
         }
+         body:not(.dark-mode) select {
+             background-image: url('data:image/svg+xml;charset=US-ASCII,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22292.4%22%20height%3D%22292.4%22%3E%3Cpath%20fill%3D%22%236c757d%22%20d%3D%22M287%2069.4a17.6%2017.6%200%200%200-13-5.4H18.4c-5%200-9.3%201.8-12.9%205.4A17.6%2017.6%200%200%200%200%2082.2c0%205%201.8%209.3%205.4%2012.9l128%20127.9c3.6%203.6%207.8%205.4%2012.8%205.4s9.2-1.8%2012.8-5.4L287%2095c3.6-3.6%205.4-7.8%205.4-12.8%200-5-1.8-9.2-5.4-12.8z%22%2F%3E%3C%2Fsvg%3E');
+        }
+        body.dark-mode select {
+            background-image: url('data:image/svg+xml;charset=US-ASCII,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22292.4%22%20height%3D%22292.4%22%3E%3Cpath%20fill%3D%22%23adbac7%22%20d%3D%22M287%2069.4a17.6%2017.6%200%200%200-13-5.4H18.4c-5%200-9.3%201.8-12.9%205.4A17.6%2017.6%200%200%200%200%2082.2c0%205%201.8%209.3%205.4%2012.9l128%20127.9c3.6%203.6%207.8%205.4%2012.8%205.4s9.2-1.8%2012.8-5.4L287%2095c3.6-3.6%205.4-7.8%205.4-12.8%200-5-1.8-9.2-5.4-12.8z%22%2F%3E%3C%2Fsvg%3E');
+        }
 
         select:disabled {
-            background-color: #e9ecef;
+            background-color: var(--header-bg); /* Updated */
             cursor: not-allowed;
             opacity: 0.7;
         }
@@ -335,11 +539,15 @@
             color: white;
             border-color: var(--primary-hover);
         }
+         body.dark-mode .checkbox-group input[type="checkbox"]:checked+label,
+         body.dark-mode .radio-group input[type="radio"]:checked+label.radio-label {
+            color: #fff;
+        }
 
         .checkbox-group input[type="checkbox"]:not(:checked)+label:hover,
         .radio-group input[type="radio"]:not(:checked)+label.radio-label:hover {
-            background-color: #e9ecef;
-            border-color: #adb5bd;
+            background-color: var(--checkbox-hover-bg); /* Updated */
+            border-color: var(--checkbox-hover-border); /* Updated */
             color: var(--text-color);
         }
 
@@ -355,7 +563,7 @@
             width: 100%;
             margin: 20px auto 30px auto;
             background-color: var(--card-bg);
-            box-shadow: 0 2px 5px rgba(0, 0, 0, 0.07);
+            box-shadow: 0 2px 5px var(--box-shadow); /* Updated */
             border-radius: 8px;
             overflow: hidden;
             border: 1px solid var(--border-color);
@@ -388,7 +596,7 @@
         }
 
         tbody tr:hover {
-            background-color: #f1f1f1;
+            background-color: var(--table-hover-bg); /* Updated */
         }
 
         td.number,
@@ -407,7 +615,7 @@
         }
 
         th.sortable:hover {
-            background-color: #dde2e6;
+            background-color: var(--th-sortable-hover-bg); /* Updated */
         }
 
         th.sortable::after {
@@ -421,12 +629,12 @@
         }
 
         th.sortable.sort-asc::after {
-            border-bottom-color: #333;
+            border-bottom-color: var(--th-sortable-arrow-color); /* Updated */
             opacity: 1;
         }
 
         th.sortable.sort-desc::after {
-            border-top-color: #333;
+            border-top-color: var(--th-sortable-arrow-color); /* Updated */
             opacity: 1;
         }
 
@@ -478,14 +686,17 @@
         }
 
         tr.qualifier {
-            background-color: #d4edda !important;
+            background-color: var(--qualifier-bg) !important; /* Updated */
+        }
+        body.dark-mode tr.qualifier td {
+            color: #e1e8ef; 
         }
 
         .player-card {
             background-color: var(--card-bg);
             padding: 25px;
             border-radius: 8px;
-            box-shadow: 0 4px 8px rgba(0, 0, 0, 0.05);
+            box-shadow: 0 4px 8px var(--box-shadow); /* Updated */
             margin-bottom: 20px;
             border: 1px solid var(--border-color);
         }
@@ -508,7 +719,7 @@
         .player-card h2 {
             margin-top: 0;
             margin-bottom: 15px;
-            border-bottom: 1px solid #eee;
+            border-bottom: 1px solid var(--border-color); /* Updated */
             padding-bottom: 10px;
             font-size: 1.3em;
             font-weight: 600;
@@ -546,7 +757,7 @@
             background-color: var(--card-bg);
             padding: 20px;
             border-radius: 8px;
-            box-shadow: 0 4px 8px rgba(0, 0, 0, 0.05);
+            box-shadow: 0 4px 8px var(--box-shadow); /* Updated */
             margin: 30px auto;
             max-width: 900px;
             border: 1px solid var(--border-color);
@@ -573,14 +784,17 @@
             border-left-color: var(--danger-color);
             color: var(--danger-color);
         }
+        body.dark-mode .error-message {
+            color: var(--danger-color-dark);
+        }
 
         .details-wrapper {
             margin-top: 30px;
             margin-bottom: 20px;
-            border: 1px solid #aaa;
+            border: 1px solid var(--details-border); /* Updated */
             border-radius: 5px;
-            background-color: #fff;
-            box-shadow: 0 3px 5px rgba(0, 0, 0, 0.07);
+            background-color: var(--card-bg); /* Updated */
+            box-shadow: 0 3px 5px var(--box-shadow); /* Updated */
         }
 
         details summary {
@@ -589,7 +803,7 @@
             font-size: 1.1em;
             padding: 10px 15px;
             background-color: var(--header-bg);
-            border-bottom: 1px solid #aaa;
+            border-bottom: 1px solid var(--details-border); /* Updated */
             border-top-left-radius: 5px;
             border-top-right-radius: 5px;
             list-style: none;
@@ -614,18 +828,21 @@
 
         details summary:focus {
             outline: none;
-            box-shadow: 0 0 0 2px rgba(0, 123, 255, 0.25);
+            box-shadow: 0 0 0 2px rgba(0, 123, 255, 0.25); /* Needs theming */
+        }
+        body.dark-mode details summary:focus {
+             box-shadow: 0 0 0 2px rgba(var(--primary-color-dark-rgb, 13, 110, 253), 0.35);
         }
 
         details .details-content {
             padding: 20px;
-            border-top: 1px solid #eee;
+            border-top: 1px solid var(--details-content-border); /* Updated */
         }
 
         details .details-content h3 {
             margin-top: 1.5em;
             margin-bottom: 0.8em;
-            border-bottom: 1px dotted #ccc;
+            border-bottom: 1px dotted var(--border-color); /* Updated */
             padding-bottom: 4px;
             font-size: 1.1em;
         }
@@ -638,21 +855,21 @@
             border: 1px solid var(--border-color);
             padding: 15px;
             margin-bottom: 25px;
-            background-color: #fdfdfd;
+            background-color: var(--carousel-bg); /* Updated */
             border-radius: 5px;
-            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+            box-shadow: 0 2px 4px var(--box-shadow); /* Updated */
         }
 
         .carousel-header {
             text-align: center;
             margin-bottom: 10px;
             padding-bottom: 5px;
-            border-bottom: 1px solid #eee;
+            border-bottom: 1px solid var(--border-color); /* Updated */
         }
 
         .carousel-header h4 {
             margin: 0;
-            color: #555;
+            color: var(--carousel-header-text); /* Updated */
             font-size: 1.1em;
             border-bottom: none;
         }
@@ -671,14 +888,14 @@
             margin-top: 0;
             margin-bottom: 10px;
             font-size: 1.15em;
-            color: #333;
+            color: var(--carousel-slide-text); /* Updated */
         }
 
         .carousel-nav {
             text-align: center;
             margin-top: 15px;
             padding-top: 10px;
-            border-top: 1px solid #eee;
+            border-top: 1px solid var(--border-color); /* Updated */
         }
 
         .carousel-nav button {
@@ -692,13 +909,16 @@
             font-size: 0.95em;
             transition: background-color 0.2s ease;
         }
+        body.dark-mode .carousel-nav button {
+             color: #fff;
+        }
 
         .carousel-nav button:hover {
             background-color: var(--primary-hover);
         }
 
         .carousel-nav button:disabled {
-            background-color: #ccc;
+            background-color: var(--carousel-nav-disabled-bg); /* Updated */
             cursor: not-allowed;
             opacity: 0.7;
         }
@@ -715,11 +935,11 @@
         }
 
         .group-overview-item {
-            border: 1px solid #e0e0e0;
+            border: 1px solid var(--group-overview-item-border); /* Updated */
             padding: 10px 15px;
             border-radius: 5px;
-            background-color: #fff;
-            box-shadow: 0 1px 3px rgba(0, 0, 0, 0.04);
+            background-color: var(--group-overview-item-bg); /* Updated */
+            box-shadow: 0 1px 3px var(--box-shadow); /* Updated */
         }
 
         .group-overview-item h4 {
@@ -727,9 +947,9 @@
             margin-bottom: 10px;
             text-align: center;
             font-size: 1.1em;
-            border-bottom: 1px solid #eee;
+            border-bottom: 1px solid var(--border-color); /* Updated */
             padding-bottom: 5px;
-            color: #333;
+            color: var(--text-color); /* Updated */
         }
 
         .group-teams-table {
@@ -745,15 +965,15 @@
             font-weight: 600;
             text-align: left;
             padding: 6px 8px;
-            color: #444;
+            color: var(--group-teams-table-header-text); /* Updated */
             border: none;
-            border-bottom: 1px solid #eee;
+            border-bottom: 1px solid var(--border-color); /* Updated */
         }
 
         .group-teams-table td {
             padding: 6px 8px;
             border: none;
-            border-bottom: 1px solid #f0f0f0;
+            border-bottom: 1px solid var(--group-teams-table-row-border); /* Updated */
             text-align: left;
         }
 
@@ -786,8 +1006,12 @@
 
         .sticky-top {
             position: sticky;
-            top: 0;
+            top: 0; 
             z-index: 100;
+            background-color: var(--header-bg); /* Ensure header is visible */
+        }
+        body.dark-mode .sticky-top {
+             background-color: var(--header-bg-dark);
         }
 
         hr {
@@ -829,17 +1053,22 @@
 
         @media (max-width: 768px) {
             body {
-                padding-top: 60px;
+                /* padding-top: 60px; */ /* Adjusted by nav-bar height */
             }
 
             .nav-bar {
                 padding: 5px 15px;
                 flex-wrap: wrap;
             }
-
+            
             .nav-toggle {
                 display: block;
                 flex-shrink: 0;
+                margin-left: 10px;
+                order: 2; /* After title */
+            }
+            #darkModeToggle {
+                order: 3; /* After nav-toggle */
                 margin-left: 10px;
             }
 
@@ -848,15 +1077,15 @@
                 flex-direction: column;
                 width: 100%;
                 align-items: flex-start;
-                background-color: white;
+                background-color: var(--nav-bar-bg); /* Updated */
                 padding-top: 10px;
                 padding-bottom: 10px;
-                box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+                box-shadow: 0 4px 6px var(--box-shadow); /* Updated */
                 position: absolute;
                 top: 100%;
                 left: 0;
                 right: 0;
-                order: 3;
+                order: 4; /* Below all other nav items */
             }
 
             .nav-links.active {
@@ -880,12 +1109,20 @@
             .nav-links a.active {
                 background-color: var(--light-bg);
                 color: var(--primary-hover);
-                border-bottom-color: var(--border-color);
+                border-bottom-color: var(--border-color); /* Or primary-hover */
+            }
+            body.dark-mode .nav-links a:hover, body.dark-mode .nav-links a.active {
+                 background-color: var(--light-bg-dark);
+                 color: var(--primary-hover-dark);
+                 border-bottom-color: var(--border-color-dark);
             }
 
             .nav-links a.active {
                 font-weight: 600;
                 border-bottom-color: var(--primary-hover);
+            }
+             body.dark-mode .nav-links a.active {
+                border-bottom-color: var(--primary-hover-dark);
             }
 
             .nav-title {
@@ -959,7 +1196,7 @@
         <button class="nav-toggle" id="navToggle" aria-label="Toggle navigation">
             &#9776; 
         </button>
-        <div class="nav-links" id="navLinks"> 
+        <div class="nav-links" id="navLinks">
             <a href="{{ url_for('index') }}" class="{{ 'active' if active_page == 'index' }}">Hlavní stránka</a>
             <a href="{{ url_for('simulation_results') }}" class="{{ 'active' if active_page == 'simulation' }}">Výsledky
                 Simulace</a>
@@ -972,6 +1209,7 @@
             <a href="{{ url_for('correlation_analysis') }}"
                 class="{{ 'active' if active_page == 'correlation' }}">Korelační Analýza</a>
         </div>
+        <button id="darkModeToggle" aria-label="Toggle dark mode">🌙</button>
     </nav>
 
     <div class="container">
@@ -1338,6 +1576,100 @@
             }, false);
         }
             });
+    </script>
+    <script>
+        const toggleButton = document.getElementById('darkModeToggle');
+        const body = document.body;
+
+        function applyTheme(theme) {
+            if (theme === 'dark') {
+                body.classList.add('dark-mode');
+                toggleButton.textContent = '☀️'; 
+                toggleButton.setAttribute('aria-label', 'Switch to Light Mode');
+                if (typeof Plotly !== 'undefined') {
+                    document.querySelectorAll('.chart-div, .chart, #radarChartContainer, #winProbChart, #eloCompareChart, #eloEvolutionChart').forEach(chartElement => {
+                        if (chartElement.layout) { 
+                            Plotly.relayout(chartElement, {
+                                'plot_bgcolor': 'var(--card-bg-dark)',
+                                'paper_bgcolor': 'var(--card-bg-dark)',
+                                'font.color': 'var(--text-color-dark)',
+                                'xaxis.color': 'var(--text-muted-dark)',
+                                'yaxis.color': 'var(--text-muted-dark)',
+                                'xaxis.gridcolor': 'var(--border-color-dark)',
+                                'yaxis.gridcolor': 'var(--border-color-dark)',
+                                'legend.bgcolor': 'var(--card-bg-dark)',
+                                'legend.bordercolor': 'var(--border-color-dark)',
+                                'polar.bgcolor': 'var(--card-bg-dark)',
+                                'polar.angularaxis.gridcolor': 'var(--border-color-dark)',
+                                'polar.radialaxis.gridcolor': 'var(--border-color-dark)',
+                                'polar.angularaxis.linecolor': 'var(--border-color-dark)',
+                                'polar.radialaxis.linecolor': 'var(--border-color-dark)',
+                                'polar.angularaxis.tickcolor': 'var(--text-muted-dark)',
+                                'polar.radialaxis.tickcolor': 'var(--text-muted-dark)',
+                            });
+                        }
+                    });
+                }
+            } else {
+                body.classList.remove('dark-mode');
+                toggleButton.textContent = '🌙'; 
+                toggleButton.setAttribute('aria-label', 'Switch to Dark Mode');
+                if (typeof Plotly !== 'undefined') {
+                    document.querySelectorAll('.chart-div, .chart, #radarChartContainer, #winProbChart, #eloCompareChart, #eloEvolutionChart').forEach(chartElement => {
+                        if (chartElement.layout) { 
+                            Plotly.relayout(chartElement, {
+                                'plot_bgcolor': 'var(--card-bg-light)',
+                                'paper_bgcolor': 'var(--card-bg-light)',
+                                'font.color': 'var(--text-color-light)',
+                                'xaxis.color': 'var(--text-muted-light)',
+                                'yaxis.color': 'var(--text-muted-light)',
+                                'xaxis.gridcolor': 'var(--border-color-light)',
+                                'yaxis.gridcolor': 'var(--border-color-light)',
+                                'legend.bgcolor': 'var(--card-bg-light)',
+                                'legend.bordercolor': 'var(--border-color-light)',
+                                'polar.bgcolor': 'var(--card-bg-light)',
+                                'polar.angularaxis.gridcolor': 'var(--border-color-light)',
+                                'polar.radialaxis.gridcolor': 'var(--border-color-light)',
+                                'polar.angularaxis.linecolor': 'var(--border-color-light)',
+                                'polar.radialaxis.linecolor': 'var(--border-color-light)',
+                                'polar.angularaxis.tickcolor': 'var(--text-muted-light)',
+                                'polar.radialaxis.tickcolor': 'var(--text-muted-light)',
+                            });
+                        }
+                    });
+                }
+            }
+        }
+
+        let savedTheme = localStorage.getItem('theme');
+        if (!savedTheme) {
+            savedTheme = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+        }
+        applyTheme(savedTheme);
+
+        toggleButton.addEventListener('click', () => {
+            const currentTheme = body.classList.contains('dark-mode') ? 'dark' : 'light';
+            const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
+            applyTheme(newTheme);
+            localStorage.setItem('theme', newTheme);
+            localStorage.setItem('theme_manual_override', 'true');
+        });
+
+        window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', event => {
+            if (!localStorage.getItem('theme_manual_override')) {
+                 const newColorScheme = event.matches ? "dark" : "light";
+                 applyTheme(newColorScheme);
+                 localStorage.setItem('theme', newColorScheme);
+            }
+        });
+        
+        setTimeout(() => {
+            if (body.classList.contains('dark-mode')) {
+                 applyTheme('dark'); 
+            } else {
+                 applyTheme('light');
+            }
+        }, 500);
     </script>
 </body>
 

--- a/euro_simulator_app copy 14/app/templates/team_roster.html
+++ b/euro_simulator_app copy 14/app/templates/team_roster.html
@@ -7,24 +7,200 @@
     <title>{{ title }} - Euro Simulátor</title>
     <style>
         :root {
-            --primary-color: #007bff;
-            --primary-hover: #0056b3;
-            --secondary-color: #6c757d;
-            --secondary-hover: #5a6268;
-            --light-bg: #f8f9fa;
-            --border-color: #dee2e6;
-            --text-color: #343a40;
-            --text-muted: #6c757d;
-            --card-bg: #ffffff;
-            --header-bg: #e9ecef;
-            --success-color: #28a745;
-            --danger-color: #dc3545;
-            --stat-better: #28a745;
-            --stat-worse: #dc3545;
-            --stat-max: #17a2b8;
-            --stat-min: #ffc107;
-            --link-color: #007bff;
-            --link-hover: #0056b3;
+            /* Light Theme Variables */
+            --primary-color-light: #007bff;
+            --primary-hover-light: #0056b3;
+            --secondary-color-light: #6c757d;
+            --secondary-hover-light: #5a6268;
+            --light-bg-light: #f8f9fa; 
+            --body-bg-light: #f4f4f4; 
+            --border-color-light: #dee2e6;
+            --text-color-light: #343a40;
+            --text-muted-light: #6c757d;
+            --card-bg-light: #ffffff;
+            --header-bg-light: #e9ecef;
+            --success-color-light: #28a745;
+            --danger-color-light: #dc3545;
+            --danger-hover-light: #c82333;
+            --stat-better-light: #28a745;
+            --stat-worse-light: #dc3545;
+            --stat-max-light: #17a2b8; 
+            --stat-min-light: #ffc107; 
+            --link-color-light: #007bff;
+            --link-hover-light: #0056b3;
+            --nav-bar-bg-light: #ffffff;
+            --select-arrow-color-light: '%236c757d'; 
+            --table-hover-bg-light: #f1f1f1;
+            --details-border-light: #aaa;
+            --details-content-border-light: #eee;
+            --carousel-bg-light: #fdfdfd;
+            --carousel-header-text-light: #555;
+            --carousel-slide-text-light: #333;
+            --carousel-nav-disabled-bg-light: #ccc;
+            --group-overview-item-bg-light: #fff;
+            --group-overview-item-border-light: #e0e0e0;
+            --group-teams-table-header-text-light: #444;
+            --group-teams-table-row-border-light: #f0f0f0;
+            --th-sortable-hover-bg-light: #dde2e6;
+            --th-sortable-arrow-color-light: #333;
+            --qualifier-bg-light: #d4edda;
+            --checkbox-hover-bg-light: #e9ecef;
+            --checkbox-hover-border-light: #adb5bd;
+            --button-disabled-bg-light: #ccc; 
+            --button-disabled-border-light: #bbb;
+            --button-disabled-text-light: #888;
+            --category-label-indeterminate-bg-light: #daf0FF;
+            --attribute-group-border-light: #ddd;
+            --box-shadow-light: rgba(0, 0, 0, 0.05);
+            --scope-toggle-hover-bg-light: #e9ecef;
+            --scope-toggle-hover-border-light: #adb5bd;
+
+
+            /* Dark Theme Variables */
+            --primary-color-dark: #0d6efd;
+            --primary-hover-dark: #3385fd;
+            --secondary-color-dark: #5c636a;
+            --secondary-hover-dark: #494f54;
+            --light-bg-dark: #22272e; 
+            --body-bg-dark: #1c2128;  
+            --border-color-dark: #444c56;
+            --text-color-dark: #adbac7;
+            --text-muted-dark: #768390;
+            --card-bg-dark: #2d333b;
+            --header-bg-dark: #373e47;
+            --success-color-dark: #34c356; 
+            --danger-color-dark: #f85149;  
+            --danger-hover-dark: #fa3d35;
+            --stat-better-dark: #34c356;
+            --stat-worse-dark: #f85149;
+            --stat-max-dark: #2cbce0; 
+            --stat-min-dark: #ffca2c; 
+            --link-color-dark: #2c8cff;
+            --link-hover-dark: #57a3ff;
+            --nav-bar-bg-dark: #2d333b;
+            --select-arrow-color-dark: '%23adbac7'; 
+            --table-hover-bg-dark: #373e47;
+            --details-border-dark: #555c66;
+            --details-content-border-dark: #444c56;
+            --carousel-bg-dark: #282e36;
+            --carousel-header-text-dark: #aab5c1;
+            --carousel-slide-text-dark: #adbac7;
+            --carousel-nav-disabled-bg-dark: #444c56;
+            --group-overview-item-bg-dark: #2d333b;
+            --group-overview-item-border-dark: #444c56;
+            --group-teams-table-header-text-dark: #adbac7;
+            --group-teams-table-row-border-dark: #373e47;
+            --th-sortable-hover-bg-dark: #404853;
+            --th-sortable-arrow-color-dark: #adbac7;
+            --qualifier-bg-dark: #2a5a3a !important; 
+            --checkbox-hover-bg-dark: #373e47;
+            --checkbox-hover-border-dark: #5a6268;
+            --button-disabled-bg-dark: #444c56;
+            --button-disabled-border-dark: #555c66;
+            --button-disabled-text-dark: #768390;
+            --category-label-indeterminate-bg-dark: #2a4a6e; 
+            --attribute-group-border-dark: var(--border-color-dark);
+            --box-shadow-dark: rgba(0, 0, 0, 0.25); 
+            --scope-toggle-hover-bg-dark: #373e47;
+            --scope-toggle-hover-border-dark: #5a6268;
+
+
+            /* Default to Light Theme */
+            --primary-color: var(--primary-color-light);
+            --primary-hover: var(--primary-hover-light);
+            --secondary-color: var(--secondary-color-light);
+            --secondary-hover: var(--secondary-hover-light);
+            --light-bg: var(--light-bg-light);
+            --body-bg: var(--body-bg-light);
+            --border-color: var(--border-color-light);
+            --text-color: var(--text-color-light);
+            --text-muted: var(--text-muted-light);
+            --card-bg: var(--card-bg-light);
+            --header-bg: var(--header-bg-light);
+            --success-color: var(--success-color-light);
+            --danger-color: var(--danger-color-light);
+            --danger-hover: var(--danger-hover-light);
+            --stat-better: var(--stat-better-light);
+            --stat-worse: var(--stat-worse-light);
+            --stat-max: var(--stat-max-light);
+            --stat-min: var(--stat-min-light);
+            --link-color: var(--link-color-light);
+            --link-hover: var(--link-hover-light);
+            --nav-bar-bg: var(--nav-bar-bg-light);
+            --select-arrow-color: var(--select-arrow-color-light);
+            --table-hover-bg: var(--table-hover-bg-light);
+            --details-border: var(--details-border-light);
+            --details-content-border: var(--details-content-border-light);
+            --carousel-bg: var(--carousel-bg-light);
+            --carousel-header-text: var(--carousel-header-text-light);
+            --carousel-slide-text: var(--carousel-slide-text-light);
+            --carousel-nav-disabled-bg: var(--carousel-nav-disabled-bg-light);
+            --group-overview-item-bg: var(--group-overview-item-bg-light);
+            --group-overview-item-border: var(--group-overview-item-border-light);
+            --group-teams-table-header-text: var(--group-teams-table-header-text-light);
+            --group-teams-table-row-border: var(--group-teams-table-row-border-light);
+            --th-sortable-hover-bg: var(--th-sortable-hover-bg-light);
+            --th-sortable-arrow-color: var(--th-sortable-arrow-color-light);
+            --qualifier-bg: var(--qualifier-bg-light);
+            --checkbox-hover-bg: var(--checkbox-hover-bg-light);
+            --checkbox-hover-border: var(--checkbox-hover-border-light);
+            --button-disabled-bg: var(--button-disabled-bg-light);
+            --button-disabled-border: var(--button-disabled-border-light);
+            --button-disabled-text: var(--button-disabled-text-light);
+            --category-label-indeterminate-bg: var(--category-label-indeterminate-bg-light);
+            --attribute-group-border: var(--attribute-group-border-light);
+            --box-shadow: var(--box-shadow-light);
+            --scope-toggle-hover-bg: var(--scope-toggle-hover-bg-light);
+            --scope-toggle-hover-border: var(--scope-toggle-hover-border-light);
+        }
+
+        body.dark-mode {
+            --primary-color: var(--primary-color-dark);
+            --primary-hover: var(--primary-hover-dark);
+            --secondary-color: var(--secondary-color-dark);
+            --secondary-hover: var(--secondary-hover-dark);
+            --light-bg: var(--light-bg-dark);
+            --body-bg: var(--body-bg-dark);
+            --border-color: var(--border-color-dark);
+            --text-color: var(--text-color-dark);
+            --text-muted: var(--text-muted-dark);
+            --card-bg: var(--card-bg-dark);
+            --header-bg: var(--header-bg-dark);
+            --success-color: var(--success-color-dark);
+            --danger-color: var(--danger-color-dark);
+            --danger-hover: var(--danger-hover-dark);
+            --stat-better: var(--stat-better-dark);
+            --stat-worse: var(--stat-worse-dark);
+            --stat-max: var(--stat-max-dark);
+            --stat-min: var(--stat-min-dark);
+            --link-color: var(--link-color-dark);
+            --link-hover: var(--link-hover-dark);
+            --nav-bar-bg: var(--nav-bar-bg-dark);
+            --select-arrow-color: var(--select-arrow-color-dark);
+            --table-hover-bg: var(--table-hover-bg-dark);
+            --details-border: var(--details-border-dark);
+            --details-content-border: var(--details-content-border-dark);
+            --carousel-bg: var(--carousel-bg-dark);
+            --carousel-header-text: var(--carousel-header-text-dark);
+            --carousel-slide-text: var(--carousel-slide-text-dark);
+            --carousel-nav-disabled-bg: var(--carousel-nav-disabled-bg-dark);
+            --group-overview-item-bg: var(--group-overview-item-bg-dark);
+            --group-overview-item-border: var(--group-overview-item-border-dark);
+            --group-teams-table-header-text: var(--group-teams-table-header-text-dark);
+            --group-teams-table-row-border: var(--group-teams-table-row-border-dark);
+            --th-sortable-hover-bg: var(--th-sortable-hover-bg-dark);
+            --th-sortable-arrow-color: var(--th-sortable-arrow-color-dark);
+            --qualifier-bg: var(--qualifier-bg-dark);
+            --checkbox-hover-bg: var(--checkbox-hover-bg-dark);
+            --checkbox-hover-border: var(--checkbox-hover-border-dark);
+            --button-disabled-bg: var(--button-disabled-bg-dark);
+            --button-disabled-border: var(--button-disabled-border-dark);
+            --button-disabled-text: var(--button-disabled-text-dark);
+            --category-label-indeterminate-bg: var(--category-label-indeterminate-bg-dark);
+            --attribute-group-border: var(--attribute-group-border-dark);
+            --box-shadow: var(--box-shadow-dark);
+            --scope-toggle-hover-bg: var(--scope-toggle-hover-bg-dark);
+            --scope-toggle-hover-border: var(--scope-toggle-hover-border-dark);
         }
 
         body {
@@ -32,7 +208,7 @@
             margin: 0;
             padding: 20px;
             line-height: 1.6;
-            background-color: #f4f4f4;
+            background-color: var(--body-bg);
             color: var(--text-color);
             position: relative;
             padding-top: 80px;
@@ -44,7 +220,7 @@
             padding: 25px;
             background-color: var(--card-bg);
             border-radius: 8px;
-            box-shadow: 0 4px 8px rgba(0, 0, 0, 0.05);
+            box-shadow: 0 4px 8px var(--box-shadow);
         }
 
         h1,
@@ -99,8 +275,8 @@
             top: 0;
             left: 0;
             right: 0;
-            background-color: white;
-            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+            background-color: var(--nav-bar-bg);
+            box-shadow: 0 2px 4px var(--box-shadow);
             z-index: 1000;
             padding: 10px 25px;
             display: flex;
@@ -115,6 +291,21 @@
             font-size: 1.2em;
             color: var(--text-color);
             flex-grow: 1;
+        }
+        
+        #darkModeToggle {
+            background-color: var(--secondary-color);
+            color: white;
+            border: none;
+            padding: 8px 12px;
+            border-radius: 6px;
+            cursor: pointer;
+            font-size: 0.9em;
+            margin-left: 15px; 
+            order: 3; 
+        }
+        body.dark-mode #darkModeToggle {
+            background-color: var(--primary-color);
         }
 
         .nav-toggle {
@@ -181,6 +372,9 @@
             border-color: var(--primary-color);
             color: white;
         }
+         body.dark-mode .btn-primary, body.dark-mode button.main-submit {
+            color: #fff;
+        }
 
         .btn-primary:hover,
         button.main-submit:hover {
@@ -197,6 +391,10 @@
             border-color: var(--secondary-color);
             color: white;
         }
+        body.dark-mode .btn-secondary, body.dark-mode a.reset-button, body.dark-mode a.back-button {
+            color: #fff;
+        }
+
 
         .btn-secondary:hover,
         a.reset-button:hover,
@@ -216,7 +414,7 @@
             background-color: var(--light-bg);
             padding: 25px;
             border-radius: 8px;
-            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+            box-shadow: 0 2px 4px var(--box-shadow);
             margin-bottom: 30px;
             border: 1px solid var(--border-color);
         }
@@ -275,15 +473,21 @@
 
         select {
             appearance: none;
-            background-image: url('data:image/svg+xml;charset=US-ASCII,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22292.4%22%20height%3D%22292.4%22%3E%3Cpath%20fill%3D%22%236c757d%22%20d%3D%22M287%2069.4a17.6%2017.6%200%200%200-13-5.4H18.4c-5%200-9.3%201.8-12.9%205.4A17.6%2017.6%200%200%200%200%2082.2c0%205%201.8%209.3%205.4%2012.9l128%20127.9c3.6%203.6%207.8%205.4%2012.8%205.4s9.2-1.8%2012.8-5.4L287%2095c3.6-3.6%205.4-7.8%205.4-12.8%200-5-1.8-9.2-5.4-12.8z%22%2F%3E%3C%2Fsvg%3E');
+            background-image: url('data:image/svg+xml;charset=US-ASCII,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22292.4%22%20height%3D%22292.4%22%3E%3Cpath%20fill%3D%22' + var(--select-arrow-color) + '%22%20d%3D%22M287%2069.4a17.6%2017.6%200%200%200-13-5.4H18.4c-5%200-9.3%201.8-12.9%205.4A17.6%2017.6%200%200%200%200%2082.2c0%205%201.8%209.3%205.4%2012.9l128%20127.9c3.6%203.6%207.8%205.4%2012.8%205.4s9.2-1.8%2012.8-5.4L287%2095c3.6-3.6%205.4-7.8%205.4-12.8%200-5-1.8-9.2-5.4-12.8z%22%2F%3E%3C%2Fsvg%3E');
             background-repeat: no-repeat;
             background-position: right 12px center;
             background-size: 10px 10px;
             padding-right: 35px;
         }
+         body:not(.dark-mode) select {
+             background-image: url('data:image/svg+xml;charset=US-ASCII,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22292.4%22%20height%3D%22292.4%22%3E%3Cpath%20fill%3D%22%236c757d%22%20d%3D%22M287%2069.4a17.6%2017.6%200%200%200-13-5.4H18.4c-5%200-9.3%201.8-12.9%205.4A17.6%2017.6%200%200%200%200%2082.2c0%205%201.8%209.3%205.4%2012.9l128%20127.9c3.6%203.6%207.8%205.4%2012.8%205.4s9.2-1.8%2012.8-5.4L287%2095c3.6-3.6%205.4-7.8%205.4-12.8%200-5-1.8-9.2-5.4-12.8z%22%2F%3E%3C%2Fsvg%3E');
+        }
+        body.dark-mode select {
+            background-image: url('data:image/svg+xml;charset=US-ASCII,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22292.4%22%20height%3D%22292.4%22%3E%3Cpath%20fill%3D%22%23adbac7%22%20d%3D%22M287%2069.4a17.6%2017.6%200%200%200-13-5.4H18.4c-5%200-9.3%201.8-12.9%205.4A17.6%2017.6%200%200%200%200%2082.2c0%205%201.8%209.3%205.4%2012.9l128%20127.9c3.6%203.6%207.8%205.4%2012.8%205.4s9.2-1.8%2012.8-5.4L287%2095c3.6-3.6%205.4-7.8%205.4-12.8%200-5-1.8-9.2-5.4-12.8z%22%2F%3E%3C%2Fsvg%3E');
+        }
 
         select:disabled {
-            background-color: #e9ecef;
+            background-color: var(--header-bg); /* Updated */
             cursor: not-allowed;
             opacity: 0.7;
         }
@@ -333,11 +537,15 @@
             color: white;
             border-color: var(--primary-hover);
         }
+         body.dark-mode .checkbox-group input[type="checkbox"]:checked+label,
+         body.dark-mode .radio-group input[type="radio"]:checked+label.radio-label {
+            color: #fff;
+        }
 
         .checkbox-group input[type="checkbox"]:not(:checked)+label:hover,
         .radio-group input[type="radio"]:not(:checked)+label.radio-label:hover {
-            background-color: #e9ecef;
-            border-color: #adb5bd;
+            background-color: var(--checkbox-hover-bg); /* Updated */
+            border-color: var(--checkbox-hover-border); /* Updated */
             color: var(--text-color);
         }
 
@@ -353,7 +561,7 @@
             width: 100%;
             margin: 20px auto 30px auto;
             background-color: var(--card-bg);
-            box-shadow: 0 2px 5px rgba(0, 0, 0, 0.07);
+            box-shadow: 0 2px 5px var(--box-shadow); /* Updated */
             border-radius: 8px;
             overflow: hidden;
             border: 1px solid var(--border-color);
@@ -386,7 +594,7 @@
         }
 
         tbody tr:hover {
-            background-color: #f1f1f1;
+            background-color: var(--table-hover-bg); /* Updated */
         }
 
         td.number,
@@ -405,7 +613,7 @@
         }
 
         th.sortable:hover {
-            background-color: #dde2e6;
+            background-color: var(--th-sortable-hover-bg); /* Updated */
         }
 
         th.sortable::after {
@@ -419,12 +627,12 @@
         }
 
         th.sortable.sort-asc::after {
-            border-bottom-color: #333;
+            border-bottom-color: var(--th-sortable-arrow-color); /* Updated */
             opacity: 1;
         }
 
         th.sortable.sort-desc::after {
-            border-top-color: #333;
+            border-top-color: var(--th-sortable-arrow-color); /* Updated */
             opacity: 1;
         }
 
@@ -476,7 +684,10 @@
         }
 
         tr.qualifier {
-            background-color: #d4edda !important;
+            background-color: var(--qualifier-bg) !important; /* Updated */
+        }
+        body.dark-mode tr.qualifier td {
+            color: #e1e8ef; 
         }
 
 
@@ -484,7 +695,7 @@
             background-color: var(--card-bg);
             padding: 25px;
             border-radius: 8px;
-            box-shadow: 0 4px 8px rgba(0, 0, 0, 0.05);
+            box-shadow: 0 4px 8px var(--box-shadow); /* Updated */
             margin-bottom: 20px;
             border: 1px solid var(--border-color);
         }
@@ -507,7 +718,7 @@
         .player-card h2 {
             margin-top: 0;
             margin-bottom: 15px;
-            border-bottom: 1px solid #eee;
+            border-bottom: 1px solid var(--border-color); /* Updated */
             padding-bottom: 10px;
             font-size: 1.3em;
             font-weight: 600;
@@ -545,7 +756,7 @@
             background-color: var(--card-bg);
             padding: 20px;
             border-radius: 8px;
-            box-shadow: 0 4px 8px rgba(0, 0, 0, 0.05);
+            box-shadow: 0 4px 8px var(--box-shadow); /* Updated */
             margin: 30px auto;
             max-width: 900px;
             border: 1px solid var(--border-color);
@@ -573,14 +784,17 @@
             border-left-color: var(--danger-color);
             color: var(--danger-color);
         }
+        body.dark-mode .error-message {
+            color: var(--danger-color-dark);
+        }
 
         .details-wrapper {
             margin-top: 30px;
             margin-bottom: 20px;
-            border: 1px solid #aaa;
+            border: 1px solid var(--details-border); /* Updated */
             border-radius: 5px;
-            background-color: #fff;
-            box-shadow: 0 3px 5px rgba(0, 0, 0, 0.07);
+            background-color: var(--card-bg); /* Updated */
+            box-shadow: 0 3px 5px var(--box-shadow); /* Updated */
         }
 
         details summary {
@@ -589,7 +803,7 @@
             font-size: 1.1em;
             padding: 10px 15px;
             background-color: var(--header-bg);
-            border-bottom: 1px solid #aaa;
+            border-bottom: 1px solid var(--details-border); /* Updated */
             border-top-left-radius: 5px;
             border-top-right-radius: 5px;
             list-style: none;
@@ -614,18 +828,21 @@
 
         details summary:focus {
             outline: none;
-            box-shadow: 0 0 0 2px rgba(0, 123, 255, 0.25);
+            box-shadow: 0 0 0 2px rgba(0, 123, 255, 0.25); /* Needs theming */
+        }
+        body.dark-mode details summary:focus {
+             box-shadow: 0 0 0 2px rgba(var(--primary-color-dark-rgb, 13, 110, 253), 0.35);
         }
 
         details .details-content {
             padding: 20px;
-            border-top: 1px solid #eee;
+            border-top: 1px solid var(--details-content-border); /* Updated */
         }
 
         details .details-content h3 {
             margin-top: 1.5em;
             margin-bottom: 0.8em;
-            border-bottom: 1px dotted #ccc;
+            border-bottom: 1px dotted var(--border-color); /* Updated */
             padding-bottom: 4px;
             font-size: 1.1em;
         }
@@ -638,21 +855,21 @@
             border: 1px solid var(--border-color);
             padding: 15px;
             margin-bottom: 25px;
-            background-color: #fdfdfd;
+            background-color: var(--carousel-bg); /* Updated */
             border-radius: 5px;
-            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+            box-shadow: 0 2px 4px var(--box-shadow); /* Updated */
         }
 
         .carousel-header {
             text-align: center;
             margin-bottom: 10px;
             padding-bottom: 5px;
-            border-bottom: 1px solid #eee;
+            border-bottom: 1px solid var(--border-color); /* Updated */
         }
 
         .carousel-header h4 {
             margin: 0;
-            color: #555;
+            color: var(--carousel-header-text); /* Updated */
             font-size: 1.1em;
             border-bottom: none;
         }
@@ -671,14 +888,14 @@
             margin-top: 0;
             margin-bottom: 10px;
             font-size: 1.15em;
-            color: #333;
+            color: var(--carousel-slide-text); /* Updated */
         }
 
         .carousel-nav {
             text-align: center;
             margin-top: 15px;
             padding-top: 10px;
-            border-top: 1px solid #eee;
+            border-top: 1px solid var(--border-color); /* Updated */
         }
 
         .carousel-nav button {
@@ -692,13 +909,16 @@
             font-size: 0.95em;
             transition: background-color 0.2s ease;
         }
+        body.dark-mode .carousel-nav button {
+             color: #fff;
+        }
 
         .carousel-nav button:hover {
             background-color: var(--primary-hover);
         }
 
         .carousel-nav button:disabled {
-            background-color: #ccc;
+            background-color: var(--carousel-nav-disabled-bg); /* Updated */
             cursor: not-allowed;
             opacity: 0.7;
         }
@@ -715,11 +935,11 @@
         }
 
         .group-overview-item {
-            border: 1px solid #e0e0e0;
+            border: 1px solid var(--group-overview-item-border); /* Updated */
             padding: 10px 15px;
             border-radius: 5px;
-            background-color: #fff;
-            box-shadow: 0 1px 3px rgba(0, 0, 0, 0.04);
+            background-color: var(--group-overview-item-bg); /* Updated */
+            box-shadow: 0 1px 3px var(--box-shadow); /* Updated */
         }
 
         .group-overview-item h4 {
@@ -727,9 +947,9 @@
             margin-bottom: 10px;
             text-align: center;
             font-size: 1.1em;
-            border-bottom: 1px solid #eee;
+            border-bottom: 1px solid var(--border-color); /* Updated */
             padding-bottom: 5px;
-            color: #333;
+            color: var(--text-color); /* Updated */
         }
 
         .group-teams-table {
@@ -745,15 +965,15 @@
             font-weight: 600;
             text-align: left;
             padding: 6px 8px;
-            color: #444;
+            color: var(--group-teams-table-header-text); /* Updated */
             border: none;
-            border-bottom: 1px solid #eee;
+            border-bottom: 1px solid var(--border-color); /* Updated */
         }
 
         .group-teams-table td {
             padding: 6px 8px;
             border: none;
-            border-bottom: 1px solid #f0f0f0;
+            border-bottom: 1px solid var(--group-teams-table-row-border); /* Updated */
             text-align: left;
         }
 
@@ -787,8 +1007,12 @@
 
         .sticky-top {
             position: sticky;
-            top: 0;
+            top: 0; 
             z-index: 100;
+            background-color: var(--header-bg); /* Ensure header is visible */
+        }
+        body.dark-mode .sticky-top {
+             background-color: var(--header-bg-dark);
         }
 
         hr {
@@ -830,17 +1054,22 @@
 
         @media (max-width: 768px) {
             body {
-                padding-top: 60px;
+                /* padding-top: 60px; */ /* Adjusted by nav-bar height */
             }
 
             .nav-bar {
                 padding: 5px 15px;
                 flex-wrap: wrap;
             }
-
+            
             .nav-toggle {
                 display: block;
                 flex-shrink: 0;
+                margin-left: 10px;
+                order: 2; /* After title */
+            }
+            #darkModeToggle {
+                order: 3; /* After nav-toggle */
                 margin-left: 10px;
             }
 
@@ -849,15 +1078,15 @@
                 flex-direction: column;
                 width: 100%;
                 align-items: flex-start;
-                background-color: white;
+                background-color: var(--nav-bar-bg); /* Updated */
                 padding-top: 10px;
                 padding-bottom: 10px;
-                box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+                box-shadow: 0 4px 6px var(--box-shadow); /* Updated */
                 position: absolute;
                 top: 100%;
                 left: 0;
                 right: 0;
-                order: 3;
+                order: 4; /* Below all other nav items */
             }
 
             .nav-links.active {
@@ -881,12 +1110,20 @@
             .nav-links a.active {
                 background-color: var(--light-bg);
                 color: var(--primary-hover);
-                border-bottom-color: var(--border-color);
+                border-bottom-color: var(--border-color); /* Or primary-hover */
+            }
+            body.dark-mode .nav-links a:hover, body.dark-mode .nav-links a.active {
+                 background-color: var(--light-bg-dark);
+                 color: var(--primary-hover-dark);
+                 border-bottom-color: var(--border-color-dark);
             }
 
             .nav-links a.active {
                 font-weight: 600;
                 border-bottom-color: var(--primary-hover);
+            }
+             body.dark-mode .nav-links a.active {
+                border-bottom-color: var(--primary-hover-dark);
             }
 
             .nav-title {
@@ -894,10 +1131,10 @@
                 margin-right: auto;
             }
 
-            .nav-toggle {
+            /* .nav-toggle {
                 display: block;
                 margin-left: 10px;
-            }
+            } */
 
 
             .container {
@@ -979,6 +1216,7 @@
             <a href="{{ url_for('correlation_analysis') }}"
                 class="{{ 'active' if active_page == 'correlation' }}">Korelační Analýza</a>
         </div>
+        <button id="darkModeToggle" aria-label="Toggle dark mode">🌙</button>
     </nav>
 
     <div class="container">
@@ -1045,6 +1283,45 @@
                         navBar.classList.remove('nav-hidden');
                     }
                 }, false);
+            }
+        });
+    </script>
+    <script>
+        const toggleButton = document.getElementById('darkModeToggle');
+        const body = document.body;
+
+        function applyTheme(theme) {
+            if (theme === 'dark') {
+                body.classList.add('dark-mode');
+                toggleButton.textContent = '☀️'; 
+                toggleButton.setAttribute('aria-label', 'Switch to Light Mode');
+                // No Plotly charts on this specific page based on the provided HTML
+            } else {
+                body.classList.remove('dark-mode');
+                toggleButton.textContent = '🌙'; 
+                toggleButton.setAttribute('aria-label', 'Switch to Dark Mode');
+            }
+        }
+
+        let savedTheme = localStorage.getItem('theme');
+        if (!savedTheme) {
+            savedTheme = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+        }
+        applyTheme(savedTheme);
+
+        toggleButton.addEventListener('click', () => {
+            const currentTheme = body.classList.contains('dark-mode') ? 'dark' : 'light';
+            const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
+            applyTheme(newTheme);
+            localStorage.setItem('theme', newTheme);
+            localStorage.setItem('theme_manual_override', 'true');
+        });
+
+        window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', event => {
+            if (!localStorage.getItem('theme_manual_override')) {
+                 const newColorScheme = event.matches ? "dark" : "light";
+                 applyTheme(newColorScheme);
+                 localStorage.setItem('theme', newColorScheme);
             }
         });
     </script>


### PR DESCRIPTION
Adds dark mode functionality across the application templates.

Key changes:
- Introduced CSS variables for light and dark themes in all relevant HTML templates (`index.html`, `attribute_distributions.html`, `correlation_analysis.html`, `descriptive_analysis.html`, `player_comparison.html`, `simulation_results.html`, `team_roster.html`).
- Added a toggle button in the navigation bar of these pages to switch between light and dark themes.
- Implemented JavaScript to handle theme toggling, save user preference in localStorage, and apply system theme preference by default.
- Updated Plotly charts to adapt to theme changes.
- Applied minimal, system-preference-based dark mode styling to error pages (`404.html`, `500.html`) for readability.